### PR TITLE
Rename project to BrokenHelper

### DIFF
--- a/BrokenHelper/BrokenHelper.csproj
+++ b/BrokenHelper/BrokenHelper.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <RootNamespace>BrokenHelper</RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.6" />
+    <PackageReference Include="SharpPcap" Version="6.3.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.6" />
+    <PackageReference Include="PacketDotNet" Version="1.4.8" />
+  </ItemGroup>
+</Project>

--- a/BrokenHelper/Program.cs
+++ b/BrokenHelper/Program.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace BrokenHelper
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Hello from BrokenHelper on .NET 8 Windows!");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- rename project folder to BrokenHelper
- update project namespace and RootNamespace
- keep Entity Framework Core, SharpPcap, and PacketDotNet dependencies targeting net8.0-windows

## Testing
- `dotnet build BrokenHelper/BrokenHelper.csproj -c Release` *(fails: `bash: dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685ad21e2bb883299507ae426cc63c0e