### PR TITLE
Add EF entities for game data model

### DIFF
--- a/BrokenHelper/Models/DropEntity.cs
+++ b/BrokenHelper/Models/DropEntity.cs
@@ -1,0 +1,25 @@
+namespace BrokenHelper.Models
+{
+    public class DropEntity
+    {
+        public int Id { get; set; }
+
+        public int FightPlayerId { get; set; }
+        public FightPlayerEntity FightPlayer { get; set; }
+
+        public DropType DropType { get; set; }
+
+        public string Name { get; set; } = string.Empty;
+
+        public int? Value { get; set; }
+
+        // Equipment-specific
+        public int? Rank { get; set; }
+        public int? OrnamentCount { get; set; }
+
+        // Orb/Drif-specific
+        public string? Code { get; set; }
+
+        public int Quantity { get; set; } = 1;
+    }
+}

--- a/BrokenHelper/Models/DropType.cs
+++ b/BrokenHelper/Models/DropType.cs
@@ -1,0 +1,10 @@
+namespace BrokenHelper.Models
+{
+    public enum DropType
+    {
+        Equipment = 1,
+        Orb = 2,
+        Drif = 3,
+        Item = 4
+    }
+}

--- a/BrokenHelper/Models/FightEntity.cs
+++ b/BrokenHelper/Models/FightEntity.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+
+namespace BrokenHelper.Models
+{
+    public class FightEntity
+    {
+        public int Id { get; set; }
+        public DateTime EndTime { get; set; }
+
+        public int? InstanceId { get; set; }
+        public InstanceEntity? Instance { get; set; }
+
+        public List<FightPlayerEntity> Players { get; set; } = new();
+        public List<FightOpponentEntity> Opponents { get; set; } = new();
+    }
+}

--- a/BrokenHelper/Models/FightOpponentEntity.cs
+++ b/BrokenHelper/Models/FightOpponentEntity.cs
@@ -1,0 +1,15 @@
+namespace BrokenHelper.Models
+{
+    public class FightOpponentEntity
+    {
+        public int Id { get; set; }
+
+        public int FightId { get; set; }
+        public FightEntity Fight { get; set; }
+
+        public int OpponentTypeId { get; set; }
+        public OpponentTypeEntity OpponentType { get; set; }
+
+        public int Quantity { get; set; }
+    }
+}

--- a/BrokenHelper/Models/FightPlayerEntity.cs
+++ b/BrokenHelper/Models/FightPlayerEntity.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+
+namespace BrokenHelper.Models
+{
+    public class FightPlayerEntity
+    {
+        public int Id { get; set; }
+
+        public int FightId { get; set; }
+        public FightEntity Fight { get; set; }
+
+        public int PlayerId { get; set; }
+        public PlayerEntity Player { get; set; }
+
+        public int Gold { get; set; }
+        public int Exp { get; set; }
+        public int Psycho { get; set; }
+
+        public List<DropEntity> Drops { get; set; } = new();
+    }
+}

--- a/BrokenHelper/Models/GameDbContext.cs
+++ b/BrokenHelper/Models/GameDbContext.cs
@@ -1,0 +1,24 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace BrokenHelper.Models
+{
+    public class GameDbContext : DbContext
+    {
+        public DbSet<InstanceEntity> Instances { get; set; }
+        public DbSet<FightEntity> Fights { get; set; }
+        public DbSet<PlayerEntity> Players { get; set; }
+        public DbSet<OpponentTypeEntity> OpponentTypes { get; set; }
+        public DbSet<FightOpponentEntity> FightOpponents { get; set; }
+        public DbSet<FightPlayerEntity> FightPlayers { get; set; }
+        public DbSet<DropEntity> Drops { get; set; }
+
+        public GameDbContext(DbContextOptions<GameDbContext> options) : base(options)
+        {
+        }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            base.OnModelCreating(modelBuilder);
+        }
+    }
+}

--- a/BrokenHelper/Models/InstanceEntity.cs
+++ b/BrokenHelper/Models/InstanceEntity.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+
+namespace BrokenHelper.Models
+{
+    public class InstanceEntity
+    {
+        public int Id { get; set; }
+        public Guid PublicId { get; set; } = Guid.NewGuid();
+        public string Name { get; set; } = string.Empty;
+        public int Difficulty { get; set; }
+        public DateTime StartTime { get; set; }
+        public DateTime EndTime { get; set; }
+
+        public List<FightEntity> Fights { get; set; } = new();
+    }
+}

--- a/BrokenHelper/Models/OpponentTypeEntity.cs
+++ b/BrokenHelper/Models/OpponentTypeEntity.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+
+namespace BrokenHelper.Models
+{
+    public class OpponentTypeEntity
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public int Level { get; set; }
+        public bool IsBoss { get; set; }
+
+        public List<FightOpponentEntity> Fights { get; set; } = new();
+    }
+}

--- a/BrokenHelper/Models/PlayerEntity.cs
+++ b/BrokenHelper/Models/PlayerEntity.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+
+namespace BrokenHelper.Models
+{
+    public class PlayerEntity
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+
+        public List<FightPlayerEntity> Fights { get; set; } = new();
+    }
+}


### PR DESCRIPTION
## Summary
- define EF Core entities to model instances, fights, players and drops
- add GameDbContext with DbSet properties

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ad6808a908329bcc2c975b09324c3