### PR TITLE
Fix packet listener build errors

### DIFF
--- a/BrokenHelper.csproj
+++ b/BrokenHelper.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net8.0-windows</TargetFramework>
     <RootNamespace>BrokenHelper</RootNamespace>
     <UseWindowsForms>true</UseWindowsForms>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.6" />

--- a/PacketListener.cs
+++ b/PacketListener.cs
@@ -18,7 +18,7 @@ namespace BrokenHelper
         {
             Directory.CreateDirectory(_dataPath);
             var devices = CaptureDeviceList.Instance;
-            _device = devices.FirstOrDefault(d => d.Interface.FriendlyName?.Contains("Wi-Fi", StringComparison.OrdinalIgnoreCase) == true)
+            _device = devices.FirstOrDefault(d => d.Description?.Contains("Wi-Fi", StringComparison.OrdinalIgnoreCase) == true)
                       ?? devices.FirstOrDefault();
             if (_device == null)
                 throw new InvalidOperationException("No capture device found");
@@ -42,7 +42,8 @@ namespace BrokenHelper
 
         private void OnPacketArrival(object sender, PacketCapture e)
         {
-            var packet = Packet.ParsePacket(e.GetPacket().LinkLayerType, e.Data);
+            var raw = e.GetPacket();
+            var packet = Packet.ParsePacket(raw.LinkLayerType, raw.Data.ToArray());
             var tcp = packet.Extract<TcpPacket>();
             if (tcp == null)
                 return;


### PR DESCRIPTION
## Summary
- enable nullable annotations in the project
- update SharpPcap device selection to use `Description`
- convert capture data to array before parsing

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ad994a6848329af1acf2a68491542