### PR TITLE
Ensure SQLite data is stored in data/data.db

### DIFF
--- a/Models/GameDbContext.cs
+++ b/Models/GameDbContext.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using System.IO;
 
 namespace BrokenHelper.Models
 {
@@ -12,8 +13,22 @@ namespace BrokenHelper.Models
         public DbSet<FightPlayerEntity> FightPlayers { get; set; }
         public DbSet<DropEntity> Drops { get; set; }
 
+        public GameDbContext()
+        {
+        }
+
         public GameDbContext(DbContextOptions<GameDbContext> options) : base(options)
         {
+        }
+
+        protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+        {
+            if (!optionsBuilder.IsConfigured)
+            {
+                Directory.CreateDirectory("data");
+                var dbPath = Path.Combine("data", "data.db");
+                optionsBuilder.UseSqlite($"Data Source={dbPath}");
+            }
         }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/Program.cs
+++ b/Program.cs
@@ -1,5 +1,7 @@
 using System;
+using System.IO;
 using System.Windows.Forms;
+using BrokenHelper.Models;
 
 namespace BrokenHelper
 {
@@ -9,6 +11,12 @@ namespace BrokenHelper
         static void Main()
         {
             ApplicationConfiguration.Initialize();
+            Directory.CreateDirectory("data");
+            using (var context = new GameDbContext())
+            {
+                context.Database.EnsureCreated();
+            }
+
             Application.Run(new MainForm());
         }
     }


### PR DESCRIPTION
## Summary
- configure EF Core to use `data/data.db`
- create data folder and ensure database exists on startup

## Testing
- `dotnet build BrokenHelper.sln -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685adad1601883299ccca1f451de73fd