### PR TITLE
Add price packet parsing

### DIFF
--- a/Models/GameDbContext.cs
+++ b/Models/GameDbContext.cs
@@ -12,6 +12,7 @@ namespace BrokenHelper.Models
         public DbSet<FightOpponentEntity> FightOpponents { get; set; }
         public DbSet<FightPlayerEntity> FightPlayers { get; set; }
         public DbSet<DropEntity> Drops { get; set; }
+        public DbSet<PriceEntity> Prices { get; set; }
 
         public GameDbContext()
         {
@@ -37,6 +38,10 @@ namespace BrokenHelper.Models
 
             modelBuilder.Entity<InstanceEntity>()
                 .HasIndex(i => i.PublicId)
+                .IsUnique();
+
+            modelBuilder.Entity<PriceEntity>()
+                .HasIndex(p => p.Name)
                 .IsUnique();
         }
     }

--- a/Models/PriceEntity.cs
+++ b/Models/PriceEntity.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace BrokenHelper.Models
+{
+    public class PriceEntity
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public int Value { get; set; }
+    }
+}

--- a/PacketListener.cs
+++ b/PacketListener.cs
@@ -96,6 +96,10 @@ namespace BrokenHelper
                 {
                     HandleInstanceMessage(rest);
                 }
+                else if (prefix == "36;0;")
+                {
+                    HandlePriceMessage(rest);
+                }
             }
         }
 
@@ -132,6 +136,42 @@ namespace BrokenHelper
             };
 
             context.Instances.Add(instance);
+            context.SaveChanges();
+        }
+
+        private void HandlePriceMessage(string message)
+        {
+            var parts = message.Split("[&&]", StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length == 0)
+                return;
+
+            using var context = new Models.GameDbContext();
+
+            foreach (var part in parts)
+            {
+                var fields = part.Split(',');
+                if (fields.Length < 3)
+                    continue;
+
+                var name = fields[1];
+                if (!int.TryParse(fields[2], out var value))
+                    continue;
+
+                var existing = context.Prices.FirstOrDefault(p => p.Name == name);
+                if (existing == null)
+                {
+                    context.Prices.Add(new Models.PriceEntity
+                    {
+                        Name = name,
+                        Value = value
+                    });
+                }
+                else
+                {
+                    existing.Value = value;
+                }
+            }
+
             context.SaveChanges();
         }
     }


### PR DESCRIPTION
## Summary
- add PriceEntity to store item prices
- update GameDbContext to include prices and unique index
- parse `36;0;` packet and save prices

## Testing
- `dotnet build BrokenHelper.csproj -c Release` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685ae57014808329b83c3d0b4bc7f8a6