### PR TITLE
Handle duplicate price entries

### DIFF
--- a/PacketListener.cs
+++ b/PacketListener.cs
@@ -366,13 +366,23 @@ namespace BrokenHelper
 
                     var name = parts.Length >= 5 ? string.Join(',', parts.Skip(4)) : parts[^1];
 
-                    var price = new Models.ArtifactPriceEntity
+                    var existing = context.ArtifactPrices.FirstOrDefault(p => p.Name == name);
+                    if (existing == null)
                     {
-                        Code = code,
-                        Value = value,
-                        Name = name
-                    };
-                    context.ArtifactPrices.Add(price);
+                        var price = new Models.ArtifactPriceEntity
+                        {
+                            Code = code,
+                            Value = value,
+                            Name = name
+                        };
+                        context.ArtifactPrices.Add(price);
+                    }
+                    else
+                    {
+                        existing.Code = code;
+                        existing.Value = value;
+                        existing.Name = name;
+                    }
                 }
                 else
                 {
@@ -383,12 +393,20 @@ namespace BrokenHelper
                     if (!int.TryParse(parts[2], out var value))
                         value = 0;
 
-                    var price = new Models.ItemPriceEntity
+                    var existing = context.ItemPrices.FirstOrDefault(p => p.Name == name);
+                    if (existing == null)
                     {
-                        Name = name,
-                        Value = value
-                    };
-                    context.ItemPrices.Add(price);
+                        var price = new Models.ItemPriceEntity
+                        {
+                            Name = name,
+                            Value = value
+                        };
+                        context.ItemPrices.Add(price);
+                    }
+                    else
+                    {
+                        existing.Value = value;
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
- update `ParsePrices` to update existing prices instead of always adding new ones
- look up artifacts by name when updating prices

## Testing
- `dotnet build BrokenHelper.csproj -clp:ErrorsOnly` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685afa0a027883299878a12584eaeb74