### PR TITLE
Continue open instance on startup

### DIFF
--- a/PacketListener.cs
+++ b/PacketListener.cs
@@ -47,6 +47,15 @@ namespace BrokenHelper
         public void Start()
         {
             Directory.CreateDirectory(_dataPath);
+            using (var context = new Models.GameDbContext())
+            {
+                var openInstance = context.Instances.FirstOrDefault(i => i.EndTime == null);
+                if (openInstance != null)
+                {
+                    _currentInstanceId = openInstance.Id;
+                }
+            }
+
             var devices = CaptureDeviceList.Instance;
             _device = devices.FirstOrDefault(d => d.Description?.Contains("Wi-Fi", StringComparison.OrdinalIgnoreCase) == true)
                       ?? devices.FirstOrDefault();

--- a/Program.cs
+++ b/Program.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using System.Windows.Forms;
 using BrokenHelper.Models;
 


### PR DESCRIPTION
## Summary
- keep database initialization only
- resume any open instance when packet listener starts

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b1d5772048329961bd5294d5ec679