### PR TITLE
Support double space separators in item lists

### DIFF
--- a/PacketListener.cs
+++ b/PacketListener.cs
@@ -314,7 +314,17 @@ namespace BrokenHelper
             if (string.IsNullOrWhiteSpace(value))
                 return Array.Empty<string>();
 
-            return value.Split('|', StringSplitOptions.RemoveEmptyEntries);
+            var parts = value.Split(new[] { "  " }, StringSplitOptions.None);
+            var result = new List<string>();
+
+            foreach (var part in parts)
+            {
+                var trimmed = part.Trim();
+                if (!string.IsNullOrEmpty(trimmed))
+                    result.Add(trimmed);
+            }
+
+            return result.ToArray();
         }
 
         private static void ParseDrifs(string? value, Models.FightPlayerEntity fightPlayer, Models.GameDbContext context)


### PR DESCRIPTION
## Summary
- allow `ParseItems` to split strings that use double spaces as separators
- remove unnecessary pipe splitting and use `StringSplitOptions.None`

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b231233f083298e7b0cb67359c8af