### PR TITLE
Add HUD overlay for fight and instance summary

### DIFF
--- a/HudForm.cs
+++ b/HudForm.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Drawing;
+using System.Linq;
+using System.Windows.Forms;
+
+namespace BrokenHelper
+{
+    public class HudForm : Form
+    {
+        private readonly Label _fightLabel;
+        private readonly Label _instanceLabel;
+        private readonly Timer _timer;
+        private readonly string _playerName;
+
+        public HudForm(string playerName)
+        {
+            _playerName = playerName;
+
+            FormBorderStyle = FormBorderStyle.None;
+            ShowInTaskbar = false;
+            TopMost = true;
+            Width = 250;
+            Height = 170;
+            StartPosition = FormStartPosition.Manual;
+            var screen = Screen.PrimaryScreen.WorkingArea;
+            Location = new Point(screen.Right - Width - 20, screen.Top + 300);
+
+            BackColor = Color.Fuchsia;
+            TransparencyKey = Color.Fuchsia;
+
+            var panel = new Panel
+            {
+                BackColor = Color.FromArgb(120, 0, 0, 0),
+                Dock = DockStyle.Fill,
+                Padding = new Padding(5)
+            };
+            Controls.Add(panel);
+
+            _fightLabel = new Label
+            {
+                ForeColor = Color.White,
+                AutoSize = true
+            };
+            panel.Controls.Add(_fightLabel);
+
+            _instanceLabel = new Label
+            {
+                ForeColor = Color.White,
+                AutoSize = true,
+                Top = _fightLabel.Bottom + 10
+            };
+            panel.Controls.Add(_instanceLabel);
+
+            _timer = new Timer { Interval = 1000 };
+            _timer.Tick += (s, e) => UpdateData();
+            _timer.Start();
+
+            UpdateData();
+        }
+
+        protected override CreateParams CreateParams
+        {
+            get
+            {
+                const int WS_EX_TRANSPARENT = 0x20;
+                const int WS_EX_LAYERED = 0x80000;
+                var cp = base.CreateParams;
+                cp.ExStyle |= WS_EX_TRANSPARENT | WS_EX_LAYERED;
+                return cp;
+            }
+        }
+
+        private void UpdateData()
+        {
+            var player = string.IsNullOrWhiteSpace(_playerName) ? StatsService.GetDefaultPlayerName() : _playerName;
+            if (string.IsNullOrWhiteSpace(player))
+            {
+                _fightLabel.Text = "";
+                _instanceLabel.Text = "";
+                return;
+            }
+
+            var fight = StatsService.GetLastFightSummary(player);
+            if (fight == null)
+            {
+                _fightLabel.Text = "Brak danych o walce";
+            }
+            else
+            {
+                _fightLabel.Text = $"Ostatnia walka:\nEXP: {fight.EarnedExp}\nPsycho: {fight.EarnedPsycho}\nGold: {fight.FoundGold}\nPrzedmioty: {fight.DropValue}";
+            }
+
+            var instance = StatsService.GetCurrentOrLastInstance(player);
+            if (instance == null)
+            {
+                _instanceLabel.Text = "Brak instancji";
+            }
+            else
+            {
+                _instanceLabel.Text = $"Instancja: {instance.Name}\nEXP: {instance.EarnedExp}\nPsycho: {instance.EarnedPsycho}\nGold: {instance.FoundGold}\nPrzedmioty: {instance.DropValue}\nCzas: {instance.Duration}";
+            }
+        }
+    }
+}
+

--- a/MainForm.Designer.cs
+++ b/MainForm.Designer.cs
@@ -26,6 +26,7 @@ namespace BrokenHelper
         {
             this.startStopButton = new System.Windows.Forms.Button();
             this.statusLabel = new System.Windows.Forms.Label();
+            this.hudCheckBox = new System.Windows.Forms.CheckBox();
             this.SuspendLayout();
             // 
             // startStopButton
@@ -37,9 +38,21 @@ namespace BrokenHelper
             this.startStopButton.Text = "Start";
             this.startStopButton.UseVisualStyleBackColor = true;
             this.startStopButton.Click += new System.EventHandler(this.startStopButton_Click);
-            // 
+
+            //
+            // hudCheckBox
+            //
+            this.hudCheckBox.AutoSize = true;
+            this.hudCheckBox.Location = new System.Drawing.Point(12, 90);
+            this.hudCheckBox.Name = "hudCheckBox";
+            this.hudCheckBox.Size = new System.Drawing.Size(89, 24);
+            this.hudCheckBox.TabIndex = 2;
+            this.hudCheckBox.Text = "Show HUD";
+            this.hudCheckBox.UseVisualStyleBackColor = true;
+            this.hudCheckBox.CheckedChanged += new System.EventHandler(this.hudCheckBox_CheckedChanged);
+            //
             // statusLabel
-            // 
+            //
             this.statusLabel.AutoSize = true;
             this.statusLabel.Location = new System.Drawing.Point(12, 55);
             this.statusLabel.Name = "statusLabel";
@@ -51,9 +64,10 @@ namespace BrokenHelper
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(200, 100);
+            this.ClientSize = new System.Drawing.Size(220, 130);
             this.Controls.Add(this.statusLabel);
             this.Controls.Add(this.startStopButton);
+            this.Controls.Add(this.hudCheckBox);
             this.Name = "MainForm";
             this.Text = "Packet Listener";
             this.ResumeLayout(false);
@@ -64,5 +78,6 @@ namespace BrokenHelper
 
         private System.Windows.Forms.Button startStopButton;
         private System.Windows.Forms.Label statusLabel;
+        private System.Windows.Forms.CheckBox hudCheckBox;
     }
 }

--- a/MainForm.cs
+++ b/MainForm.cs
@@ -6,6 +6,7 @@ namespace BrokenHelper
     public partial class MainForm : Form
     {
         private PacketListener? _listener;
+        private HudForm? _hud;
 
         public MainForm()
         {
@@ -27,6 +28,21 @@ namespace BrokenHelper
                 _listener = null;
                 startStopButton.Text = "Start";
                 statusLabel.Text = "Stopped";
+            }
+        }
+
+        private void hudCheckBox_CheckedChanged(object sender, EventArgs e)
+        {
+            if (hudCheckBox.Checked)
+            {
+                var player = StatsService.GetDefaultPlayerName();
+                _hud = new HudForm(player);
+                _hud.Show();
+            }
+            else
+            {
+                _hud?.Close();
+                _hud = null;
             }
         }
     }

--- a/StatsService.cs
+++ b/StatsService.cs
@@ -226,5 +226,69 @@ namespace BrokenHelper
 
             return new FightsSummary(exp, psycho, gold, dropValue, fightCount, dropsGrouped);
         }
+
+        public static string GetDefaultPlayerName()
+        {
+            using var context = new GameDbContext();
+            return context.Players.Select(p => p.Name).FirstOrDefault() ?? string.Empty;
+        }
+
+        public static FightsSummary? GetLastFightSummary(string playerName)
+        {
+            using var context = new GameDbContext();
+
+            var lastFightId = context.FightPlayers
+                .Include(fp => fp.Fight)
+                .Where(fp => fp.Player.Name == playerName)
+                .OrderByDescending(fp => fp.Fight.EndTime)
+                .Select(fp => fp.FightId)
+                .FirstOrDefault();
+
+            return lastFightId == 0 ? null : SummarizeFights(playerName, new[] { lastFightId });
+        }
+
+        public static InstanceInfo? GetCurrentOrLastInstance(string playerName)
+        {
+            using var context = new GameDbContext();
+
+            var itemPrices = context.ItemPrices.ToDictionary(p => p.Name, p => p.Value);
+            var artifactPrices = context.ArtifactPrices.ToDictionary(p => p.Code, p => p.Value);
+
+            var instancesQuery = context.Instances
+                .Include(i => i.Fights).ThenInclude(f => f.Players).ThenInclude(fp => fp.Drops)
+                .OrderByDescending(i => i.StartTime);
+
+            var instance = instancesQuery.FirstOrDefault(i => i.EndTime == null) ?? instancesQuery.FirstOrDefault();
+            if (instance == null)
+                return null;
+
+            var fights = instance.Fights;
+            var playerFights = fights.SelectMany(f => f.Players)
+                .Where(fp => fp.Player.Name == playerName)
+                .ToList();
+            if (playerFights.Count == 0)
+                return null;
+
+            int exp = playerFights.Sum(fp => fp.Exp);
+            int psycho = playerFights.Sum(fp => fp.Psycho);
+            int gold = playerFights.Sum(fp => fp.Gold);
+            int dropsValue = playerFights.SelectMany(fp => fp.Drops)
+                .Sum(d => GetDropValue(d, itemPrices, artifactPrices));
+
+            string duration = instance.EndTime.HasValue
+                ? (instance.EndTime.Value - instance.StartTime).ToString(@"mm\:ss")
+                : (DateTime.Now - instance.StartTime).ToString(@"mm\:ss");
+
+            return new InstanceInfo(
+                instance.StartTime,
+                instance.Name,
+                instance.Difficulty,
+                duration,
+                exp,
+                psycho,
+                gold,
+                dropsValue,
+                fights.Count);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- implement lightweight HUD form showing last fight and current instance stats
- add helper methods to `StatsService` for summaries and player detection
- add HUD toggle checkbox in main form
- display HUD in the top right corner when enabled

## Testing
- `dotnet build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685b3ce7aaa083299031d35e6b6e8914