### PR TITLE
Add tray menu and HUD

### DIFF
--- a/HudForm.cs
+++ b/HudForm.cs
@@ -1,0 +1,24 @@
+using System.Windows.Forms;
+
+namespace BrokenHelper
+{
+    public class HudForm : Form
+    {
+        private readonly Label _label = new() { Text = "HUD", AutoSize = true };
+
+        public HudForm()
+        {
+            FormBorderStyle = FormBorderStyle.None;
+            StartPosition = FormStartPosition.Manual;
+            TopMost = true;
+            Width = 200;
+            Height = 100;
+            BackColor = System.Drawing.Color.Black;
+            ForeColor = System.Drawing.Color.Lime;
+
+            Controls.Add(_label);
+            _label.Left = 10;
+            _label.Top = 10;
+        }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -18,7 +18,7 @@ namespace BrokenHelper
                 context.Database.EnsureCreated();
             }
 
-            Application.Run(new MainForm());
+            Application.Run(new TrayAppContext());
         }
     }
 }

--- a/TrayAppContext.cs
+++ b/TrayAppContext.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Windows.Forms;
+
+namespace BrokenHelper
+{
+    public class TrayAppContext : ApplicationContext
+    {
+        private readonly NotifyIcon _notifyIcon;
+        private readonly ToolStripMenuItem _startStopMenuItem;
+        private readonly ToolStripMenuItem _hudMenuItem;
+
+        private PacketListener? _listener;
+        private FightsDashboard? _fightsDashboard;
+        private InstancesDashboard? _instancesDashboard;
+        private HudForm? _hudForm;
+
+        public TrayAppContext()
+        {
+            _startStopMenuItem = new ToolStripMenuItem("Zacznij nasłuchiwanie");
+            _startStopMenuItem.Click += StartStopMenuItem_Click;
+
+            _hudMenuItem = new ToolStripMenuItem("Włącz HUD");
+            _hudMenuItem.Click += HudMenuItem_Click;
+
+            var menu = new ContextMenuStrip();
+            menu.Items.Add(_startStopMenuItem);
+            menu.Items.Add(new ToolStripSeparator());
+            menu.Items.Add("Instancje", null, (_, _) => ShowInstances());
+            menu.Items.Add("Walki", null, (_, _) => ShowFights());
+            menu.Items.Add(_hudMenuItem);
+            menu.Items.Add(new ToolStripSeparator());
+            menu.Items.Add("Wyłącz aplikację", null, (_, _) => ExitThread());
+
+            _notifyIcon = new NotifyIcon
+            {
+                Text = "BRoken Helper",
+                Icon = System.Drawing.SystemIcons.Application,
+                ContextMenuStrip = menu,
+                Visible = true
+            };
+        }
+
+        private void StartStopMenuItem_Click(object? sender, EventArgs e)
+        {
+            if (_listener == null)
+            {
+                _listener = new PacketListener();
+                _listener.Start();
+                _startStopMenuItem.Text = "Zatrzymaj nasłuchiwanie";
+            }
+            else
+            {
+                _listener.Stop();
+                _listener = null;
+                _startStopMenuItem.Text = "Zacznij nasłuchiwanie";
+            }
+        }
+
+        private void ShowFights()
+        {
+            _fightsDashboard ??= new FightsDashboard();
+            _fightsDashboard.Show();
+            _fightsDashboard.BringToFront();
+        }
+
+        private void ShowInstances()
+        {
+            _instancesDashboard ??= new InstancesDashboard();
+            _instancesDashboard.Show();
+            _instancesDashboard.BringToFront();
+        }
+
+        private void HudMenuItem_Click(object? sender, EventArgs e)
+        {
+            if (_hudForm == null || _hudForm.IsDisposed)
+            {
+                _hudForm = new HudForm();
+                _hudForm.FormClosed += (_, _) => { _hudMenuItem.Text = "Włącz HUD"; _hudForm = null; };
+                _hudForm.Show();
+                _hudMenuItem.Text = "Wyłącz HUD";
+            }
+            else
+            {
+                _hudForm.Close();
+                _hudForm = null;
+                _hudMenuItem.Text = "Włącz HUD";
+            }
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _notifyIcon.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement `TrayAppContext` with NotifyIcon
- add simple `HudForm` overlay
- update `Program` to run tray application context

## Testing
- `dotnet build --no-restore` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685b9d1d8824832992e1cf3bc689333f