### PR TITLE
Fix HUD initialization and entity null warnings

### DIFF
--- a/FightsDashboard.cs
+++ b/FightsDashboard.cs
@@ -125,7 +125,7 @@ namespace BrokenHelper
             {
                 if ((bool)(row.Cells[0].Value ?? false))
                 {
-                    ids.Add((int)row.Tag);
+                    ids.Add((int)row.Tag!);
                 }
             }
             if (ids.Count == 0) return;

--- a/HudForm.cs
+++ b/HudForm.cs
@@ -22,7 +22,7 @@ namespace BrokenHelper
             Width = 250;
             Height = 170;
             StartPosition = FormStartPosition.Manual;
-            var screen = Screen.PrimaryScreen.WorkingArea;
+            var screen = Screen.PrimaryScreen?.WorkingArea ?? Rectangle.Empty;
             Location = new Point(screen.Right - Width - 20, screen.Top + 300);
 
             BackColor = Color.Fuchsia;

--- a/InstancesDashboard.cs
+++ b/InstancesDashboard.cs
@@ -122,7 +122,7 @@ namespace BrokenHelper
             {
                 if ((bool)(row.Cells[0].Value ?? false))
                 {
-                    ids.Add((int)row.Tag);
+                    ids.Add((int)row.Tag!);
                 }
             }
             if (ids.Count == 0) return;

--- a/Models/DropEntity.cs
+++ b/Models/DropEntity.cs
@@ -5,7 +5,7 @@ namespace BrokenHelper.Models
         public int Id { get; set; }
 
         public int FightPlayerId { get; set; }
-        public FightPlayerEntity FightPlayer { get; set; }
+        public FightPlayerEntity FightPlayer { get; set; } = null!;
 
         public DropType DropType { get; set; }
 

--- a/Models/FightOpponentEntity.cs
+++ b/Models/FightOpponentEntity.cs
@@ -5,10 +5,10 @@ namespace BrokenHelper.Models
         public int Id { get; set; }
 
         public int FightId { get; set; }
-        public FightEntity Fight { get; set; }
+        public FightEntity Fight { get; set; } = null!;
 
         public int OpponentTypeId { get; set; }
-        public OpponentTypeEntity OpponentType { get; set; }
+        public OpponentTypeEntity OpponentType { get; set; } = null!;
 
         public int Quantity { get; set; }
     }

--- a/Models/FightPlayerEntity.cs
+++ b/Models/FightPlayerEntity.cs
@@ -7,10 +7,10 @@ namespace BrokenHelper.Models
         public int Id { get; set; }
 
         public int FightId { get; set; }
-        public FightEntity Fight { get; set; }
+        public FightEntity Fight { get; set; } = null!;
 
         public int PlayerId { get; set; }
-        public PlayerEntity Player { get; set; }
+        public PlayerEntity Player { get; set; } = null!;
 
         public int Gold { get; set; }
         public int Exp { get; set; }

--- a/StatsService.cs
+++ b/StatsService.cs
@@ -283,6 +283,7 @@ namespace BrokenHelper
                 : (DateTime.Now - instance.StartTime).ToString(@"mm\:ss");
 
             return new InstanceInfo(
+                instance.Id,
                 instance.StartTime,
                 instance.Name,
                 instance.Difficulty,

--- a/TrayAppContext.cs
+++ b/TrayAppContext.cs
@@ -74,7 +74,8 @@ namespace BrokenHelper
         {
             if (_hudForm == null || _hudForm.IsDisposed)
             {
-                _hudForm = new HudForm();
+                var player = StatsService.GetDefaultPlayerName();
+                _hudForm = new HudForm(player);
                 _hudForm.FormClosed += (_, _) => { _hudMenuItem.Text = "Włącz HUD"; _hudForm = null; };
                 _hudForm.Show();
                 _hudMenuItem.Text = "Wyłącz HUD";


### PR DESCRIPTION
## Summary
- initialize HUD with default player name in tray context
- include instance ID when creating `InstanceInfo`
- avoid `Screen.PrimaryScreen` null dereference
- mark nullable entity navigation properties
- fix possible null casts in dashboards

## Testing
- `dotnet build BrokenHelper.csproj -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ba0253c7483298e0cd3482b3f4c77