### PR TITLE
Fix dashboard window reuse after close

### DIFF
--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -49,14 +49,22 @@ namespace BrokenHelper
 
         private void FightsMenuItem_Click(object sender, RoutedEventArgs e)
         {
-            _fightsDashboard ??= new FightsDashboardWindow();
+            if (_fightsDashboard == null)
+            {
+                _fightsDashboard = new FightsDashboardWindow();
+                _fightsDashboard.Closed += (_, _) => _fightsDashboard = null;
+            }
             _fightsDashboard.Show();
             _fightsDashboard.Activate();
         }
 
         private void InstancesMenuItem_Click(object sender, RoutedEventArgs e)
         {
-            _instancesDashboard ??= new InstancesDashboardWindow();
+            if (_instancesDashboard == null)
+            {
+                _instancesDashboard = new InstancesDashboardWindow();
+                _instancesDashboard.Closed += (_, _) => _instancesDashboard = null;
+            }
             _instancesDashboard.Show();
             _instancesDashboard.Activate();
         }


### PR DESCRIPTION
## Summary
- reset dashboard fields when the corresponding window closes

## Testing
- `dotnet build BrokenHelper.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bb05f5af4832981c8d4fec736e621