### PR TITLE
Remove unused filter from GetInstances

### DIFF
--- a/InstancesDashboardWindow.xaml.cs
+++ b/InstancesDashboardWindow.xaml.cs
@@ -24,7 +24,7 @@ namespace BrokenHelper
             grid.ItemsSource = null;
             var from = fromPicker.SelectedDate ?? DateTime.Today;
             var to = (toPicker.SelectedDate ?? DateTime.Today).AddDays(1);
-            var data = StatsService.GetInstances(GetPlayerName(), from, to, false);
+            var data = StatsService.GetInstances(GetPlayerName(), from, to);
             grid.ItemsSource = data;
         }
 

--- a/StatsService.cs
+++ b/StatsService.cs
@@ -40,7 +40,7 @@ namespace BrokenHelper
         }
 
         public static List<InstanceInfo> GetInstances(string playerName,
-            DateTime from, DateTime to, bool onlyWithoutInstance)
+            DateTime from, DateTime to)
         {
             using var context = new GameDbContext();
 


### PR DESCRIPTION
## Summary
- remove the unused `onlyWithoutInstance` argument from `StatsService.GetInstances`
- update `InstancesDashboardWindow` call site

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bb05fa0ec832997adbc2c93d6c50e