### PR TITLE
Improve HUD spacing & list rendering

### DIFF
--- a/FightsDashboardWindow.xaml
+++ b/FightsDashboardWindow.xaml
@@ -16,8 +16,8 @@
             <DataGrid.Columns>
                 <DataGridCheckBoxColumn Width="30"/>
                 <DataGridTextColumn Binding="{Binding Time}" Header="Czas" />
-                <DataGridTextColumn Binding="{Binding Players}" Header="Gracze" />
-                <DataGridTextColumn Binding="{Binding Opponents}" Header="Przeciwnicy" />
+                <DataGridTextColumn Binding="{Binding PlayersText}" Header="Gracze" />
+                <DataGridTextColumn Binding="{Binding OpponentsText}" Header="Przeciwnicy" />
                 <DataGridTextColumn Binding="{Binding EarnedExp}" Header="Exp" />
                 <DataGridTextColumn Binding="{Binding EarnedPsycho}" Header="Psycho" />
                 <DataGridTextColumn Binding="{Binding FoundGold}" Header="Gold" />

--- a/HudWindow.xaml.cs
+++ b/HudWindow.xaml.cs
@@ -32,6 +32,8 @@ namespace BrokenHelper
 
             var fightPanel = CreateHudTable();
             var instancePanel = CreateHudTable();
+            fightPanel.Margin = new Thickness(10, 0, 10, 5);
+            instancePanel.Margin = new Thickness(10, 5, 10, 0);
             container.Children.Add(fightPanel);
             container.Children.Add(instancePanel);
 

--- a/StatsService.cs
+++ b/StatsService.cs
@@ -12,7 +12,11 @@ namespace BrokenHelper
 
     public record FightInfo(int Id, DateTime Time, List<string> Players,
         List<string> Opponents, int EarnedExp, int EarnedPsycho,
-        int FoundGold, int DropValue, string Drops);
+        int FoundGold, int DropValue, string Drops)
+    {
+        public string PlayersText => string.Join(", ", Players);
+        public string OpponentsText => string.Join(", ", Opponents);
+    }
 
     public record DropSummary(string Name, int Quantity, int Value);
 


### PR DESCRIPTION
## Summary
- add margins to separate fight and instance sections in HUD
- show player & opponent lists correctly in fights grid
- expose formatted player/opponent strings via `FightInfo`

## Testing
- `dotnet build BrokenHelper.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bb1776f38832989e1077ca070b751