### PR TITLE
Add manual instance creation and remove selection checkboxes

### DIFF
--- a/CreateInstanceWindow.xaml
+++ b/CreateInstanceWindow.xaml
@@ -1,0 +1,30 @@
+<Window x:Class="BrokenHelper.CreateInstanceWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Stwórz instancję" Height="200" Width="300" WindowStartupLocation="CenterOwner">
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto"/>
+            <ColumnDefinition Width="*"/>
+        </Grid.ColumnDefinitions>
+        <Label Content="Nazwa:" Grid.Row="0" Grid.Column="0" Margin="0,0,5,5"/>
+        <TextBox x:Name="nameBox" Grid.Row="0" Grid.Column="1" Margin="0,0,0,5"/>
+        <Label Content="Poziom:" Grid.Row="1" Grid.Column="0" Margin="0,0,5,5"/>
+        <TextBox x:Name="difficultyBox" Grid.Row="1" Grid.Column="1" Margin="0,0,0,5"/>
+        <Label Content="Start:" Grid.Row="2" Grid.Column="0" Margin="0,0,5,5"/>
+        <TextBox x:Name="startBox" Grid.Row="2" Grid.Column="1" Margin="0,0,0,5"/>
+        <Label Content="Koniec:" Grid.Row="3" Grid.Column="0" Margin="0,0,5,5"/>
+        <TextBox x:Name="endBox" Grid.Row="3" Grid.Column="1" Margin="0,0,0,5"/>
+        <StackPanel Orientation="Horizontal" Grid.Row="4" Grid.ColumnSpan="2" HorizontalAlignment="Right" Margin="0,10,0,0">
+            <Button Content="OK" Width="70" Margin="0,0,5,0" Click="Ok_Click"/>
+            <Button Content="Anuluj" Width="70" Click="Cancel_Click"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/CreateInstanceWindow.xaml.cs
+++ b/CreateInstanceWindow.xaml.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Windows;
+
+namespace BrokenHelper
+{
+    public partial class CreateInstanceWindow : Window
+    {
+        public string InstanceName => nameBox.Text;
+        public int Difficulty => int.TryParse(difficultyBox.Text, out var d) ? d : 0;
+        public DateTime StartTime => DateTime.TryParse(startBox.Text, out var s) ? s : DateTime.Now;
+        public DateTime? EndTime => DateTime.TryParse(endBox.Text, out var e) ? e : (DateTime?)null;
+
+        public CreateInstanceWindow(string defaultName, DateTime start, DateTime end)
+        {
+            InitializeComponent();
+            nameBox.Text = defaultName;
+            difficultyBox.Text = "1";
+            startBox.Text = start.ToString("yyyy-MM-dd HH:mm:ss");
+            endBox.Text = end.ToString("yyyy-MM-dd HH:mm:ss");
+        }
+
+        private void Ok_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = true;
+        }
+
+        private void Cancel_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+        }
+    }
+}

--- a/FightsDashboardWindow.xaml
+++ b/FightsDashboardWindow.xaml
@@ -11,10 +11,10 @@
             <Button x:Name="today" Content="Dziś" Margin="5,0" Click="Today_Click"/>
             <CheckBox x:Name="withoutInstance" Content="Tylko bez instancji" Margin="5,0" Checked="FilterChanged" Unchecked="FilterChanged"/>
             <Button x:Name="summary" Content="Podsumuj" Margin="5,0" Click="Summary_Click"/>
+            <Button x:Name="createInstance" Content="Stwórz instancję" Margin="5,0" Click="CreateInstance_Click"/>
         </StackPanel>
         <DataGrid x:Name="grid" AutoGenerateColumns="False" DockPanel.Dock="Top">
             <DataGrid.Columns>
-                <DataGridCheckBoxColumn Width="30"/>
                 <DataGridTextColumn Binding="{Binding Time}" Header="Czas" />
                 <DataGridTextColumn Binding="{Binding PlayersText}" Header="Gracze" />
                 <DataGridTextColumn Binding="{Binding OpponentsText}" Header="Przeciwnicy" />

--- a/FightsDashboardWindow.xaml.cs
+++ b/FightsDashboardWindow.xaml.cs
@@ -57,5 +57,31 @@ namespace BrokenHelper
             var drops = string.Join("\n", summary.Drops.Select(d => $"{d.Name}: {d.Quantity} (wartość {d.Value})"));
             MessageBox.Show($"Walk: {summary.FightCount}\nExp: {summary.EarnedExp}\nPsycho: {summary.EarnedPsycho}\nGold: {summary.FoundGold}\nDrop: {summary.DropValue}\n\n{drops}", "Podsumowanie");
         }
+
+        private void CreateInstance_Click(object sender, RoutedEventArgs e)
+        {
+            var selected = grid.SelectedItems.Cast<FightInfo>().ToList();
+            if (selected.Count == 0)
+                return;
+
+            if (selected.Any(f => f.InstanceId != null))
+            {
+                MessageBox.Show("Wszystkie zaznaczone walki muszą być bez instancji");
+                return;
+            }
+
+            var start = selected.Min(f => f.Time).AddSeconds(-10);
+            var end = selected.Max(f => f.Time);
+            var window = new CreateInstanceWindow(StatsService.LastInstanceName, start, end)
+            {
+                Owner = this
+            };
+            if (window.ShowDialog() == true)
+            {
+                StatsService.LastInstanceName = window.InstanceName;
+                StatsService.CreateInstance(window.InstanceName, window.Difficulty, window.StartTime, window.EndTime, selected.Select(f => f.Id));
+                RefreshData();
+            }
+        }
     }
 }

--- a/InstancesDashboardWindow.xaml
+++ b/InstancesDashboardWindow.xaml
@@ -13,7 +13,6 @@
         </StackPanel>
         <DataGrid x:Name="grid" AutoGenerateColumns="False" DockPanel.Dock="Top">
             <DataGrid.Columns>
-                <DataGridCheckBoxColumn Width="30"/>
                 <DataGridTextColumn Binding="{Binding StartTime}" Header="Start" />
                 <DataGridTextColumn Binding="{Binding Name}" Header="Nazwa" />
                 <DataGridTextColumn Binding="{Binding Difficulty}" Header="Poziom" />


### PR DESCRIPTION
## Summary
- drop DataGridCheckBoxColumn usage
- add "Stwórz instancję" button for fights
- support creating instances from selected fights
- remember last used instance name

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bb558098883298e66900fb4afd0b7