### PR TITLE
Fix add instance dialog size

### DIFF
--- a/CreateInstanceWindow.xaml
+++ b/CreateInstanceWindow.xaml
@@ -1,7 +1,7 @@
 <Window x:Class="BrokenHelper.CreateInstanceWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Stwórz instancję" Height="200" Width="300" WindowStartupLocation="CenterOwner">
+        Title="Stwórz instancję" Height="230" Width="300" WindowStartupLocation="CenterOwner">
     <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>


### PR DESCRIPTION
## Summary
- increase default height of create instance dialog so action buttons are visible

## Testing
- `dotnet --version` *(fails: command not found)*
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bbf8cf66c832994efdcf5a829dac3