### PR TITLE
Add thousand separator formatting

### DIFF
--- a/FightsDashboardWindow.xaml
+++ b/FightsDashboardWindow.xaml
@@ -1,6 +1,7 @@
 <Window x:Class="BrokenHelper.FightsDashboardWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="clr-namespace:BrokenHelper"
         Title="Lista walk" Height="600" Width="800">
     <DockPanel>
         <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="5">
@@ -14,14 +15,17 @@
             <Button x:Name="createInstance" Content="Stwórz instancję" Margin="5,0" Click="CreateInstance_Click"/>
         </StackPanel>
         <DataGrid x:Name="grid" AutoGenerateColumns="False" DockPanel.Dock="Top">
+            <DataGrid.Resources>
+                <local:ThousandsSeparatorConverter x:Key="Sep" />
+            </DataGrid.Resources>
             <DataGrid.Columns>
                 <DataGridTextColumn Binding="{Binding Time}" Header="Czas" />
                 <DataGridTextColumn Binding="{Binding PlayersText}" Header="Gracze" />
                 <DataGridTextColumn Binding="{Binding OpponentsText}" Header="Przeciwnicy" />
-                <DataGridTextColumn Binding="{Binding EarnedExp}" Header="Exp" />
-                <DataGridTextColumn Binding="{Binding EarnedPsycho}" Header="Psycho" />
-                <DataGridTextColumn Binding="{Binding FoundGold}" Header="Gold" />
-                <DataGridTextColumn Binding="{Binding DropValue}" Header="Drop" />
+                <DataGridTextColumn Binding="{Binding EarnedExp, Converter={StaticResource Sep}}" Header="Exp" />
+                <DataGridTextColumn Binding="{Binding EarnedPsycho, Converter={StaticResource Sep}}" Header="Psycho" />
+                <DataGridTextColumn Binding="{Binding FoundGold, Converter={StaticResource Sep}}" Header="Gold" />
+                <DataGridTextColumn Binding="{Binding DropValue, Converter={StaticResource Sep}}" Header="Drop" />
                 <DataGridTextColumn Binding="{Binding Drops}" Header="Przedmioty" />
             </DataGrid.Columns>
         </DataGrid>

--- a/InstancesDashboardWindow.xaml
+++ b/InstancesDashboardWindow.xaml
@@ -1,6 +1,7 @@
 <Window x:Class="BrokenHelper.InstancesDashboardWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:local="clr-namespace:BrokenHelper"
         Title="Lista instancji" Height="600" Width="800">
     <DockPanel>
         <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Margin="5">
@@ -12,16 +13,19 @@
             <Button x:Name="summary" Content="Podsumuj" Margin="5,0" Click="Summary_Click"/>
         </StackPanel>
         <DataGrid x:Name="grid" AutoGenerateColumns="False" DockPanel.Dock="Top">
+            <DataGrid.Resources>
+                <local:ThousandsSeparatorConverter x:Key="Sep" />
+            </DataGrid.Resources>
             <DataGrid.Columns>
                 <DataGridTextColumn Binding="{Binding StartTime}" Header="Start" />
                 <DataGridTextColumn Binding="{Binding Name}" Header="Nazwa" />
                 <DataGridTextColumn Binding="{Binding Difficulty}" Header="Poziom" />
                 <DataGridTextColumn Binding="{Binding Duration}" Header="Czas" />
-                <DataGridTextColumn Binding="{Binding EarnedExp}" Header="Exp" />
-                <DataGridTextColumn Binding="{Binding EarnedPsycho}" Header="Psycho" />
-                <DataGridTextColumn Binding="{Binding FoundGold}" Header="Gold" />
-                <DataGridTextColumn Binding="{Binding DropValue}" Header="Drop" />
-                <DataGridTextColumn Binding="{Binding FightCount}" Header="Walki" />
+                <DataGridTextColumn Binding="{Binding EarnedExp, Converter={StaticResource Sep}}" Header="Exp" />
+                <DataGridTextColumn Binding="{Binding EarnedPsycho, Converter={StaticResource Sep}}" Header="Psycho" />
+                <DataGridTextColumn Binding="{Binding FoundGold, Converter={StaticResource Sep}}" Header="Gold" />
+                <DataGridTextColumn Binding="{Binding DropValue, Converter={StaticResource Sep}}" Header="Drop" />
+                <DataGridTextColumn Binding="{Binding FightCount, Converter={StaticResource Sep}}" Header="Walki" />
             </DataGrid.Columns>
         </DataGrid>
     </DockPanel>

--- a/ThousandsSeparatorConverter.cs
+++ b/ThousandsSeparatorConverter.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace BrokenHelper
+{
+    public class ThousandsSeparatorConverter : IValueConverter
+    {
+        public object? Convert(object value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            if (value == null)
+                return null;
+
+            if (value is IFormattable formattable)
+                return formattable.ToString("N0", CultureInfo.InvariantCulture).Replace(',', ' ');
+
+            return value.ToString();
+        }
+
+        public object ConvertBack(object value, Type targetType, object? parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- show spaces as thousand separators in tables
- implement `ThousandsSeparatorConverter`
- use converter in fights and instances dashboards

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bc024801c83298bd02ba96e120bc7