### PR TITLE
Improve summary layout

### DIFF
--- a/PodsumowanieViewModel.cs
+++ b/PodsumowanieViewModel.cs
@@ -12,27 +12,37 @@ namespace BrokenHelper
         public int TotalPsycho { get; set; }
         public int TotalProfit { get; set; }
 
-        public List<string> EquipmentList { get; set; } = new();
-        public List<string> ArtifactList { get; set; } = new();
-        public List<string> ItemList { get; set; } = new();
+        public List<string> EquipmentList { get; private set; } = new();
+        public List<string> ArtifactList { get; private set; } = new();
+        public List<string> ItemList { get; private set; } = new();
+
+        public int EquipmentSum { get; private set; }
+        public int ArtifactSum { get; private set; }
+        public int ItemSum { get; private set; }
 
         public void LoadData(List<DropSummaryDetailed> drops)
         {
-            var equipment = drops.Where(d => d.Type == "Equipment");
-            var artifacts = drops.Where(d => d.Type == "Artifact");
-            var items = drops.Where(d => d.Type == "Item");
+            SetListAndSum(drops.Where(d => d.Type == "Equipment"), out var eqList, out var eqSum);
+            EquipmentList = eqList;
+            EquipmentSum = eqSum;
 
-            EquipmentList = FormatList(equipment);
-            ArtifactList = FormatList(artifacts);
-            ItemList = FormatList(items);
+            SetListAndSum(drops.Where(d => d.Type == "Artifact"), out var artList, out var artSum);
+            ArtifactList = artList;
+            ArtifactSum = artSum;
+
+            SetListAndSum(drops.Where(d => d.Type == "Item"), out var itemList, out var itemSum);
+            ItemList = itemList;
+            ItemSum = itemSum;
         }
 
-        private List<string> FormatList(IEnumerable<DropSummaryDetailed> drops)
+        private static void SetListAndSum(IEnumerable<DropSummaryDetailed> source, out List<string> result, out int sum)
         {
-            return drops
+            var sorted = source
                 .OrderByDescending(d => d.TotalValue)
-                .Select(d => $"{d.Name,-30} {d.Quantity} x {d.UnitPrice:N0} = {d.TotalValue:N0}")
+                .Select(d => $"{d.Name,-28} {d.Quantity} x {d.UnitPrice:N0} = {d.TotalValue:N0}".Replace(',', ' '))
                 .ToList();
+            result = sorted;
+            sum = source.Sum(d => d.TotalValue);
         }
     }
 }

--- a/Views/PanelPodsumowania.xaml
+++ b/Views/PanelPodsumowania.xaml
@@ -1,54 +1,99 @@
 <Window x:Class="BrokenHelper.Views.PanelPodsumowania"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        Title="Podsumowanie Walk" Height="800" Width="1000"
+        xmlns:local="clr-namespace:BrokenHelper"
+        Title="Podsumowanie Walk" Height="800" Width="1100"
         Background="#222" Foreground="#EEE" FontFamily="Consolas" FontSize="14"
         WindowStartupLocation="CenterOwner">
+    <Window.Resources>
+        <local:ThousandsSeparatorConverter x:Key="Sep" />
+    </Window.Resources>
     <Grid Margin="20">
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="1.2*"/>
-            <ColumnDefinition Width="2*"/>
-        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
 
-        <!-- Statystyki ogólne -->
-        <StackPanel Grid.Column="0" Margin="10">
-            <TextBlock Text="📊 Statystyki Ogólne" FontSize="18" FontWeight="Bold" Margin="0 0 0 10"/>
-            <TextBlock Text="{Binding InstanceCount, StringFormat='Ilość instancji: {0}'}" Margin="0 5"/>
-            <TextBlock Text="{Binding FightCount, StringFormat='Ilość walk: {0}'}" Margin="0 5"/>
-            <TextBlock Text="{Binding TotalGold, StringFormat='Suma złota: {0:N0}'}" Margin="0 5"/>
-            <TextBlock Text="{Binding TotalExp, StringFormat='Suma EXP: {0:N0}'}" Margin="0 5"/>
-            <TextBlock Text="{Binding TotalPsycho, StringFormat='Suma psycho: {0:N0}'}" Margin="0 5"/>
-            <TextBlock Text="{Binding TotalProfit, StringFormat='Całkowity zarobek: {0:N0}'}" Margin="0 5"/>
-        </StackPanel>
+        <Grid Grid.Row="1">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="1.2*"/>
+                <ColumnDefinition Width="1.8*"/>
+            </Grid.ColumnDefinitions>
 
-        <!-- Wykazy -->
-        <StackPanel Grid.Column="1" Margin="10" Orientation="Vertical">
-            <TextBlock Text="🎒 Zdobyte Ekwipunki" FontSize="16" FontWeight="Bold" Margin="0 0 0 5"/>
-            <ListView ItemsSource="{Binding EquipmentList}" Margin="0 0 0 15" Height="160">
-                <ListView.ItemTemplate>
-                    <DataTemplate>
-                        <TextBlock Text="{Binding}" />
-                    </DataTemplate>
-                </ListView.ItemTemplate>
-            </ListView>
+            <!-- Statystyki -->
+            <StackPanel Grid.Column="0" Margin="10">
+                <TextBlock Text="📊 Statystyki Ogólne" FontSize="18" FontWeight="Bold" Margin="0 0 0 10"/>
+                <UniformGrid Columns="2" Margin="0 5 0 0">
+                    <TextBlock Text="Ilość instancji:" />
+                    <TextBlock Text="{Binding InstanceCount, Converter={StaticResource Sep}}" TextAlignment="Right"/>
 
-            <TextBlock Text="💎 Zdobyte Artefakty" FontSize="16" FontWeight="Bold" Margin="0 0 0 5"/>
-            <ListView ItemsSource="{Binding ArtifactList}" Margin="0 0 0 15" Height="160">
-                <ListView.ItemTemplate>
-                    <DataTemplate>
-                        <TextBlock Text="{Binding}" />
-                    </DataTemplate>
-                </ListView.ItemTemplate>
-            </ListView>
+                    <TextBlock Text="Ilość walk:" />
+                    <TextBlock Text="{Binding FightCount, Converter={StaticResource Sep}}" TextAlignment="Right"/>
 
-            <TextBlock Text="📦 Zdobyte Przedmioty" FontSize="16" FontWeight="Bold" Margin="0 0 0 5"/>
-            <ListView ItemsSource="{Binding ItemList}" Height="160">
-                <ListView.ItemTemplate>
-                    <DataTemplate>
-                        <TextBlock Text="{Binding}" />
-                    </DataTemplate>
-                </ListView.ItemTemplate>
-            </ListView>
-        </StackPanel>
+                    <TextBlock Text="Suma złota:" />
+                    <TextBlock Text="{Binding TotalGold, Converter={StaticResource Sep}}" TextAlignment="Right"/>
+
+                    <TextBlock Text="Suma EXP:" />
+                    <TextBlock Text="{Binding TotalExp, Converter={StaticResource Sep}}" TextAlignment="Right"/>
+
+                    <TextBlock Text="Suma psycho:" />
+                    <TextBlock Text="{Binding TotalPsycho, Converter={StaticResource Sep}}" TextAlignment="Right"/>
+
+                    <TextBlock Text="Całkowity zarobek:" />
+                    <TextBlock Text="{Binding TotalProfit, Converter={StaticResource Sep}}" TextAlignment="Right"/>
+                </UniformGrid>
+            </StackPanel>
+
+            <!-- Wykazy -->
+            <Grid Grid.Column="1" Margin="10">
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="*"/>
+                    <RowDefinition Height="*"/>
+                </Grid.RowDefinitions>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="1*"/>
+                    <ColumnDefinition Width="1*"/>
+                </Grid.ColumnDefinitions>
+
+                <!-- Ekwipunek -->
+                <StackPanel Grid.Row="0" Grid.Column="0" Margin="5">
+                    <TextBlock Text="🛡 Zdobyty Ekwipunek" FontSize="16" FontWeight="Bold" Margin="0 0 0 5"/>
+                    <ItemsControl ItemsSource="{Binding EquipmentList}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding}" TextWrapping="Wrap"/>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                    <TextBlock Text="{Binding EquipmentSum, Converter={StaticResource Sep}, StringFormat=Razem: {0}}" FontWeight="Bold" Margin="0 5 0 0"/>
+                </StackPanel>
+
+                <!-- Artefakty -->
+                <StackPanel Grid.Row="1" Grid.Column="0" Margin="5">
+                    <TextBlock Text="💎 Zdobyte Artefakty" FontSize="16" FontWeight="Bold" Margin="0 0 0 5"/>
+                    <ItemsControl ItemsSource="{Binding ArtifactList}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding}" TextWrapping="Wrap"/>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                    <TextBlock Text="{Binding ArtifactSum, Converter={StaticResource Sep}, StringFormat=Razem: {0}}" FontWeight="Bold" Margin="0 5 0 0"/>
+                </StackPanel>
+
+                <!-- Przedmioty -->
+                <StackPanel Grid.Row="1" Grid.Column="1" Margin="5">
+                    <TextBlock Text="📦 Zdobyte Przedmioty" FontSize="16" FontWeight="Bold" Margin="0 0 0 5"/>
+                    <ItemsControl ItemsSource="{Binding ItemList}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding}" TextWrapping="Wrap"/>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                    <TextBlock Text="{Binding ItemSum, Converter={StaticResource Sep}, StringFormat=Razem: {0}}" FontWeight="Bold" Margin="0 5 0 0"/>
+                </StackPanel>
+            </Grid>
+        </Grid>
     </Grid>
 </Window>


### PR DESCRIPTION
## Summary
- restyle summary window into a 2x2 grid
- display stats with right-aligned numbers and space separators
- use read-only lists for loot and add totals for each list

## Testing
- `dotnet build BrokenHelper.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bc53ddd9083299153510e40599907