### PR TITLE
Fix null reference on instance lookup

### DIFF
--- a/StatsService.cs
+++ b/StatsService.cs
@@ -346,7 +346,7 @@ namespace BrokenHelper
 
             var fights = instance.Fights;
             var playerFights = fights.SelectMany(f => f.Players)
-                .Where(fp => fp.Player.Name == playerName)
+                .Where(fp => fp.Player != null && fp.Player.Name == playerName)
                 .ToList();
             if (playerFights.Count == 0)
                 return null;


### PR DESCRIPTION
## Summary
- prevent null reference in `GetCurrentOrLastInstance` by guarding against missing Player relation

## Testing
- `dotnet build BrokenHelper.csproj -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bddb5cd708329a2b6bde052fec055