### PR TITLE
Update fight summary layout

### DIFF
--- a/PodsumowanieViewModel.cs
+++ b/PodsumowanieViewModel.cs
@@ -10,6 +10,7 @@ namespace BrokenHelper
         public int TotalGold { get; set; }
         public int TotalExp { get; set; }
         public int TotalPsycho { get; set; }
+        public int TotalDropValue { get; set; }
         public int TotalProfit { get; set; }
 
         public List<string> EquipmentList { get; private set; } = new();

--- a/Views/FightsDashboardWindow.xaml.cs
+++ b/Views/FightsDashboardWindow.xaml.cs
@@ -65,6 +65,7 @@ namespace BrokenHelper
                 TotalGold = summary.FoundGold,
                 TotalExp = summary.EarnedExp,
                 TotalPsycho = summary.EarnedPsycho,
+                TotalDropValue = summary.DropValue,
                 TotalProfit = summary.FoundGold + summary.DropValue
             };
             vm.LoadData(details);

--- a/Views/InstancesDashboardWindow.xaml.cs
+++ b/Views/InstancesDashboardWindow.xaml.cs
@@ -65,6 +65,7 @@ namespace BrokenHelper
                 TotalGold = summary.FoundGold,
                 TotalExp = summary.EarnedExp,
                 TotalPsycho = summary.EarnedPsycho,
+                TotalDropValue = summary.DropValue,
                 TotalProfit = summary.FoundGold + summary.DropValue
             };
             vm.LoadData(details);

--- a/Views/PanelPodsumowania.xaml
+++ b/Views/PanelPodsumowania.xaml
@@ -2,7 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:BrokenHelper"
-        Title="Podsumowanie Walk" Height="800" Width="1100"
+        Title="Podsumowanie Walk" Height="800" Width="1300"
         Background="#222" Foreground="#EEE" FontFamily="Consolas" FontSize="14"
         WindowStartupLocation="CenterOwner">
     <Window.Resources>
@@ -15,61 +15,47 @@
         </Grid.RowDefinitions>
 
         <Grid Grid.Row="1">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
                 <ColumnDefinition Width="1.2*"/>
                 <ColumnDefinition Width="1.8*"/>
             </Grid.ColumnDefinitions>
 
             <!-- Statystyki -->
-            <StackPanel Grid.Column="0" Margin="10">
-                <TextBlock Text="📊 Statystyki Ogólne" FontSize="18" FontWeight="Bold" Margin="0 0 0 10"/>
-                <UniformGrid Columns="2" Margin="0 5 0 0">
-                    <TextBlock Text="Ilość instancji:" />
-                    <TextBlock Text="{Binding InstanceCount, Converter={StaticResource Sep}}" TextAlignment="Right"/>
+            <Border Grid.Row="0" Grid.Column="0" Margin="5" Background="#333" Padding="10" CornerRadius="5">
+                <StackPanel>
+                    <TextBlock Text="📊 Statystyki Ogólne" FontSize="18" FontWeight="Bold" Margin="0 0 0 10"/>
+                    <UniformGrid Columns="2" Margin="0 5 0 0">
+                        <TextBlock Text="Ilość instancji:" />
+                        <TextBlock Text="{Binding InstanceCount, Converter={StaticResource Sep}}" TextAlignment="Right"/>
 
-                    <TextBlock Text="Ilość walk:" />
-                    <TextBlock Text="{Binding FightCount, Converter={StaticResource Sep}}" TextAlignment="Right"/>
+                        <TextBlock Text="Ilość walk:" />
+                        <TextBlock Text="{Binding FightCount, Converter={StaticResource Sep}}" TextAlignment="Right"/>
 
-                    <TextBlock Text="Suma złota:" />
-                    <TextBlock Text="{Binding TotalGold, Converter={StaticResource Sep}}" TextAlignment="Right"/>
+                        <TextBlock Text="Suma złota:" />
+                        <TextBlock Text="{Binding TotalGold, Converter={StaticResource Sep}}" TextAlignment="Right"/>
 
-                    <TextBlock Text="Suma EXP:" />
-                    <TextBlock Text="{Binding TotalExp, Converter={StaticResource Sep}}" TextAlignment="Right"/>
+                        <TextBlock Text="Suma EXP:" />
+                        <TextBlock Text="{Binding TotalExp, Converter={StaticResource Sep}}" TextAlignment="Right"/>
 
-                    <TextBlock Text="Suma psycho:" />
-                    <TextBlock Text="{Binding TotalPsycho, Converter={StaticResource Sep}}" TextAlignment="Right"/>
+                        <TextBlock Text="Suma psycho:" />
+                        <TextBlock Text="{Binding TotalPsycho, Converter={StaticResource Sep}}" TextAlignment="Right"/>
 
-                    <TextBlock Text="Całkowity zarobek:" />
-                    <TextBlock Text="{Binding TotalProfit, Converter={StaticResource Sep}}" TextAlignment="Right"/>
-                </UniformGrid>
-            </StackPanel>
+                        <TextBlock Text="Wartość przedmiotów:" />
+                        <TextBlock Text="{Binding TotalDropValue, Converter={StaticResource Sep}}" TextAlignment="Right"/>
 
-            <!-- Wykazy -->
-            <Grid Grid.Column="1" Margin="10">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="*"/>
-                    <RowDefinition Height="*"/>
-                </Grid.RowDefinitions>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="1*"/>
-                    <ColumnDefinition Width="1*"/>
-                </Grid.ColumnDefinitions>
-
-                <!-- Ekwipunek -->
-                <StackPanel Grid.Row="0" Grid.Column="0" Margin="5">
-                    <TextBlock Text="🛡 Zdobyty Ekwipunek" FontSize="16" FontWeight="Bold" Margin="0 0 0 5"/>
-                    <ItemsControl ItemsSource="{Binding EquipmentList}">
-                        <ItemsControl.ItemTemplate>
-                            <DataTemplate>
-                                <TextBlock Text="{Binding}" TextWrapping="Wrap"/>
-                            </DataTemplate>
-                        </ItemsControl.ItemTemplate>
-                    </ItemsControl>
-                    <TextBlock Text="{Binding EquipmentSum, Converter={StaticResource Sep}, StringFormat=Razem: {0}}" FontWeight="Bold" Margin="0 5 0 0"/>
+                        <TextBlock Text="Całkowity zarobek:" />
+                        <TextBlock Text="{Binding TotalProfit, Converter={StaticResource Sep}}" TextAlignment="Right"/>
+                    </UniformGrid>
                 </StackPanel>
+            </Border>
 
-                <!-- Artefakty -->
-                <StackPanel Grid.Row="1" Grid.Column="0" Margin="5">
+            <!-- Artefakty -->
+            <Border Grid.Row="1" Grid.Column="0" Margin="5" Background="#333" Padding="10" CornerRadius="5">
+                <StackPanel>
                     <TextBlock Text="💎 Zdobyte Artefakty" FontSize="16" FontWeight="Bold" Margin="0 0 0 5"/>
                     <ItemsControl ItemsSource="{Binding ArtifactList}">
                         <ItemsControl.ItemTemplate>
@@ -80,9 +66,26 @@
                     </ItemsControl>
                     <TextBlock Text="{Binding ArtifactSum, Converter={StaticResource Sep}, StringFormat=Razem: {0}}" FontWeight="Bold" Margin="0 5 0 0"/>
                 </StackPanel>
+            </Border>
 
-                <!-- Przedmioty -->
-                <StackPanel Grid.Row="1" Grid.Column="1" Margin="5">
+            <!-- Ekwipunek -->
+            <Border Grid.Row="0" Grid.Column="1" Margin="5" Background="#333" Padding="10" CornerRadius="5">
+                <StackPanel>
+                    <TextBlock Text="🛡 Zdobyty Ekwipunek" FontSize="16" FontWeight="Bold" Margin="0 0 0 5"/>
+                    <ItemsControl ItemsSource="{Binding EquipmentList}">
+                        <ItemsControl.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding}" TextWrapping="Wrap"/>
+                            </DataTemplate>
+                        </ItemsControl.ItemTemplate>
+                    </ItemsControl>
+                    <TextBlock Text="{Binding EquipmentSum, Converter={StaticResource Sep}, StringFormat=Razem: {0}}" FontWeight="Bold" Margin="0 5 0 0"/>
+                </StackPanel>
+            </Border>
+
+            <!-- Przedmioty -->
+            <Border Grid.Row="1" Grid.Column="1" Margin="5" Background="#333" Padding="10" CornerRadius="5">
+                <StackPanel>
                     <TextBlock Text="📦 Zdobyte Przedmioty" FontSize="16" FontWeight="Bold" Margin="0 0 0 5"/>
                     <ItemsControl ItemsSource="{Binding ItemList}">
                         <ItemsControl.ItemTemplate>
@@ -93,7 +96,7 @@
                     </ItemsControl>
                     <TextBlock Text="{Binding ItemSum, Converter={StaticResource Sep}, StringFormat=Razem: {0}}" FontWeight="Bold" Margin="0 5 0 0"/>
                 </StackPanel>
-            </Grid>
+            </Border>
         </Grid>
     </Grid>
 </Window>


### PR DESCRIPTION
## Summary
- rename `Całkowity Zarobek` label to `Wartość przedmiotów`
- show total item value using new `TotalDropValue` property
- keep total profit value below the new label
- move artifact list below general stats for a 2x2 layout
- add borders with padding for each section and widen the window

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c02cca2048329ae4a94f531ec5d36