### PR TITLE
Rename summary view to English and format item lists

### DIFF
--- a/SummaryViewModel.cs
+++ b/SummaryViewModel.cs
@@ -3,7 +3,7 @@ using System.Linq;
 
 namespace BrokenHelper
 {
-    public class PodsumowanieViewModel
+    public class SummaryViewModel
     {
         public int InstanceCount { get; set; }
         public int FightCount { get; set; }
@@ -14,26 +14,30 @@ namespace BrokenHelper
         public int TotalProfit { get; set; }
         public string TotalInstanceTime { get; set; } = string.Empty;
 
-        public List<string> EquipmentList { get; private set; } = new();
-        public List<string> ArtifactList { get; private set; } = new();
-        public List<string> ItemList { get; private set; } = new();
+        public List<string> FormattedEquipmentList { get; private set; } = new();
+        public List<string> FormattedArtifactList { get; private set; } = new();
+        public List<string> FormattedItemList { get; private set; } = new();
 
         public int EquipmentSum { get; private set; }
         public int ArtifactSum { get; private set; }
         public int ItemSum { get; private set; }
 
+        public string EquipmentSumFormatted => EquipmentSum.ToString("N0").Replace(',', ' ');
+        public string ArtifactSumFormatted => ArtifactSum.ToString("N0").Replace(',', ' ');
+        public string ItemSumFormatted => ItemSum.ToString("N0").Replace(',', ' ');
+
         public void LoadData(List<DropSummaryDetailed> drops)
         {
             SetListAndSum(drops.Where(d => d.Type == "Equipment"), out var eqList, out var eqSum);
-            EquipmentList = eqList;
+            FormattedEquipmentList = eqList;
             EquipmentSum = eqSum;
 
             SetListAndSum(drops.Where(d => d.Type == "Artifact"), out var artList, out var artSum);
-            ArtifactList = artList;
+            FormattedArtifactList = artList;
             ArtifactSum = artSum;
 
             SetListAndSum(drops.Where(d => d.Type == "Item"), out var itemList, out var itemSum);
-            ItemList = itemList;
+            FormattedItemList = itemList;
             ItemSum = itemSum;
         }
 

--- a/Views/FightsDashboardWindow.xaml.cs
+++ b/Views/FightsDashboardWindow.xaml.cs
@@ -69,7 +69,7 @@ namespace BrokenHelper
                 totalDuration += StatsService.GetInstanceDuration(id);
             }
 
-            var vm = new PodsumowanieViewModel
+            var vm = new SummaryViewModel
             {
                 InstanceCount = instanceIds.Count,
                 FightCount = summary.FightCount,
@@ -82,7 +82,7 @@ namespace BrokenHelper
             };
             vm.LoadData(details);
 
-            var window = new Views.PanelPodsumowania
+            var window = new Views.SummaryPanel
             {
                 DataContext = vm,
                 Owner = this

--- a/Views/InstancesDashboardWindow.xaml.cs
+++ b/Views/InstancesDashboardWindow.xaml.cs
@@ -64,7 +64,7 @@ namespace BrokenHelper
                 totalDuration += StatsService.GetInstanceDuration(inst.Id);
             }
 
-            var vm = new PodsumowanieViewModel
+            var vm = new SummaryViewModel
             {
                 InstanceCount = selected.Count,
                 FightCount = summary.FightCount,
@@ -77,7 +77,7 @@ namespace BrokenHelper
             };
             vm.LoadData(details);
 
-            var window = new Views.PanelPodsumowania
+            var window = new Views.SummaryPanel
             {
                 DataContext = vm,
                 Owner = this

--- a/Views/SummaryPanel.xaml
+++ b/Views/SummaryPanel.xaml
@@ -1,4 +1,4 @@
-<Window x:Class="BrokenHelper.Views.PanelPodsumowania"
+<Window x:Class="BrokenHelper.Views.SummaryPanel"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:local="clr-namespace:BrokenHelper"
@@ -60,14 +60,15 @@
             <Border Grid.Row="1" Grid.Column="0" Margin="5" Background="#333" Padding="10" CornerRadius="5">
                 <StackPanel>
                     <TextBlock Text="💎 Zdobyte Artefakty" FontSize="16" FontWeight="Bold" Margin="0 0 0 5"/>
-                    <ItemsControl ItemsSource="{Binding ArtifactList}">
+                    <!-- Formatowane ręcznie -->
+                    <ItemsControl ItemsSource="{Binding FormattedArtifactList}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <TextBlock Text="{Binding}" TextWrapping="Wrap"/>
+                                <TextBlock Text="{Binding}" FontFamily="Consolas" TextAlignment="Left"/>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
-                    <TextBlock Text="{Binding ArtifactSum, Converter={StaticResource Sep}, StringFormat=Razem: {0}}" FontWeight="Bold" Margin="0 5 0 0"/>
+                    <TextBlock Text="{Binding ArtifactSumFormatted}" FontWeight="Bold" Margin="0 5 0 0" FontFamily="Consolas"/>
                 </StackPanel>
             </Border>
 
@@ -75,14 +76,15 @@
             <Border Grid.Row="0" Grid.Column="1" Margin="5" Background="#333" Padding="10" CornerRadius="5">
                 <StackPanel>
                     <TextBlock Text="🛡 Zdobyty Ekwipunek" FontSize="16" FontWeight="Bold" Margin="0 0 0 5"/>
-                    <ItemsControl ItemsSource="{Binding EquipmentList}">
+                    <!-- Formatowane ręcznie -->
+                    <ItemsControl ItemsSource="{Binding FormattedEquipmentList}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <TextBlock Text="{Binding}" TextWrapping="Wrap"/>
+                                <TextBlock Text="{Binding}" FontFamily="Consolas" TextAlignment="Left"/>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
-                    <TextBlock Text="{Binding EquipmentSum, Converter={StaticResource Sep}, StringFormat=Razem: {0}}" FontWeight="Bold" Margin="0 5 0 0"/>
+                    <TextBlock Text="{Binding EquipmentSumFormatted}" FontWeight="Bold" Margin="0 5 0 0" FontFamily="Consolas"/>
                 </StackPanel>
             </Border>
 
@@ -90,14 +92,15 @@
             <Border Grid.Row="1" Grid.Column="1" Margin="5" Background="#333" Padding="10" CornerRadius="5">
                 <StackPanel>
                     <TextBlock Text="📦 Zdobyte Przedmioty" FontSize="16" FontWeight="Bold" Margin="0 0 0 5"/>
-                    <ItemsControl ItemsSource="{Binding ItemList}">
+                    <!-- Formatowane ręcznie -->
+                    <ItemsControl ItemsSource="{Binding FormattedItemList}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <TextBlock Text="{Binding}" TextWrapping="Wrap"/>
+                                <TextBlock Text="{Binding}" FontFamily="Consolas" TextAlignment="Left"/>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
-                    <TextBlock Text="{Binding ItemSum, Converter={StaticResource Sep}, StringFormat=Razem: {0}}" FontWeight="Bold" Margin="0 5 0 0"/>
+                    <TextBlock Text="{Binding ItemSumFormatted}" FontWeight="Bold" Margin="0 5 0 0" FontFamily="Consolas"/>
                 </StackPanel>
             </Border>
         </Grid>

--- a/Views/SummaryPanel.xaml.cs
+++ b/Views/SummaryPanel.xaml.cs
@@ -2,9 +2,9 @@ using System.Windows;
 
 namespace BrokenHelper.Views
 {
-    public partial class PanelPodsumowania : Window
+    public partial class SummaryPanel : Window
     {
-        public PanelPodsumowania()
+        public SummaryPanel()
         {
             InitializeComponent();
         }


### PR DESCRIPTION
## Summary
- rename panel and view model files from Polish to English
- update bindings for formatted item lists in `SummaryPanel`
- add formatted properties in `SummaryViewModel`

## Testing
- `dotnet build -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c05d0b9988329b41bd74e01574c59