### PR TITLE
Update loot summary formatting

### DIFF
--- a/DropSummaryDetailed.cs
+++ b/DropSummaryDetailed.cs
@@ -7,5 +7,6 @@ namespace BrokenHelper
         public int Quantity { get; set; }
         public int UnitPrice { get; set; }
         public int TotalValue => Quantity * UnitPrice;
+        public int TotalPrice => TotalValue;
     }
 }

--- a/SummaryViewModel.cs
+++ b/SummaryViewModel.cs
@@ -14,9 +14,9 @@ namespace BrokenHelper
         public int TotalProfit { get; set; }
         public string TotalInstanceTime { get; set; } = string.Empty;
 
-        public List<string> FormattedEquipmentList { get; private set; } = new();
-        public List<string> FormattedArtifactList { get; private set; } = new();
-        public List<string> FormattedItemList { get; private set; } = new();
+        public List<DropSummaryDetailed> EquipmentList { get; private set; } = new();
+        public List<DropSummaryDetailed> ArtifactList { get; private set; } = new();
+        public List<DropSummaryDetailed> ItemList { get; private set; } = new();
 
         public int EquipmentSum { get; private set; }
         public int ArtifactSum { get; private set; }
@@ -29,26 +29,25 @@ namespace BrokenHelper
         public void LoadData(List<DropSummaryDetailed> drops)
         {
             SetListAndSum(drops.Where(d => d.Type == "Equipment"), out var eqList, out var eqSum);
-            FormattedEquipmentList = eqList;
+            EquipmentList = eqList;
             EquipmentSum = eqSum;
 
             SetListAndSum(drops.Where(d => d.Type == "Artifact"), out var artList, out var artSum);
-            FormattedArtifactList = artList;
+            ArtifactList = artList;
             ArtifactSum = artSum;
 
             SetListAndSum(drops.Where(d => d.Type == "Item"), out var itemList, out var itemSum);
-            FormattedItemList = itemList;
+            ItemList = itemList;
             ItemSum = itemSum;
         }
 
-        private static void SetListAndSum(IEnumerable<DropSummaryDetailed> source, out List<string> result, out int sum)
+        private static void SetListAndSum(IEnumerable<DropSummaryDetailed> source, out List<DropSummaryDetailed> result, out int sum)
         {
             var sorted = source
                 .OrderByDescending(d => d.TotalValue)
-                .Select(d => $"{d.Name,-28} {d.Quantity} x {d.UnitPrice:N0} = {d.TotalValue:N0}".Replace(',', ' '))
                 .ToList();
             result = sorted;
-            sum = source.Sum(d => d.TotalValue);
+            sum = sorted.Sum(d => d.TotalValue);
         }
     }
 }

--- a/Views/SummaryPanel.xaml
+++ b/Views/SummaryPanel.xaml
@@ -60,15 +60,34 @@
             <Border Grid.Row="1" Grid.Column="0" Margin="5" Background="#333" Padding="10" CornerRadius="5">
                 <StackPanel>
                     <TextBlock Text="💎 Zdobyte Artefakty" FontSize="16" FontWeight="Bold" Margin="0 0 0 5"/>
-                    <!-- Formatowane ręcznie -->
-                    <ItemsControl ItemsSource="{Binding FormattedArtifactList}">
+                    <ItemsControl ItemsSource="{Binding ArtifactList}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <TextBlock Text="{Binding}" FontFamily="Consolas" TextAlignment="Left"/>
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="40" />
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="80" />
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0" Text="{Binding Name}" TextWrapping="Wrap"/>
+                                    <TextBlock Grid.Column="1" Text=" * " HorizontalAlignment="Center"/>
+                                    <TextBlock Grid.Column="2" Text="{Binding Quantity}" HorizontalAlignment="Right"/>
+                                    <TextBlock Grid.Column="3" Text=" = " HorizontalAlignment="Center"/>
+                                    <TextBlock Grid.Column="4" Text="{Binding TotalPrice, StringFormat=N0}" HorizontalAlignment="Right"/>
+                                </Grid>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
-                    <TextBlock Text="{Binding ArtifactSumFormatted}" FontWeight="Bold" Margin="0 5 0 0" FontFamily="Consolas"/>
+                    <Grid Margin="0 5 0 0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Text="Razem:" FontWeight="Bold" Grid.Column="0" />
+                        <TextBlock Text="{Binding ArtifactSumFormatted}" FontWeight="Bold" Grid.Column="1" HorizontalAlignment="Right"/>
+                    </Grid>
                 </StackPanel>
             </Border>
 
@@ -76,15 +95,34 @@
             <Border Grid.Row="0" Grid.Column="1" Margin="5" Background="#333" Padding="10" CornerRadius="5">
                 <StackPanel>
                     <TextBlock Text="🛡 Zdobyty Ekwipunek" FontSize="16" FontWeight="Bold" Margin="0 0 0 5"/>
-                    <!-- Formatowane ręcznie -->
-                    <ItemsControl ItemsSource="{Binding FormattedEquipmentList}">
+                    <ItemsControl ItemsSource="{Binding EquipmentList}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <TextBlock Text="{Binding}" FontFamily="Consolas" TextAlignment="Left"/>
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="40" />
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="80" />
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0" Text="{Binding Name}" TextWrapping="Wrap"/>
+                                    <TextBlock Grid.Column="1" Text=" * " HorizontalAlignment="Center"/>
+                                    <TextBlock Grid.Column="2" Text="{Binding Quantity}" HorizontalAlignment="Right"/>
+                                    <TextBlock Grid.Column="3" Text=" = " HorizontalAlignment="Center"/>
+                                    <TextBlock Grid.Column="4" Text="{Binding TotalPrice, StringFormat=N0}" HorizontalAlignment="Right"/>
+                                </Grid>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
-                    <TextBlock Text="{Binding EquipmentSumFormatted}" FontWeight="Bold" Margin="0 5 0 0" FontFamily="Consolas"/>
+                    <Grid Margin="0 5 0 0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Text="Razem:" FontWeight="Bold" Grid.Column="0" />
+                        <TextBlock Text="{Binding EquipmentSumFormatted}" FontWeight="Bold" Grid.Column="1" HorizontalAlignment="Right"/>
+                    </Grid>
                 </StackPanel>
             </Border>
 
@@ -92,15 +130,34 @@
             <Border Grid.Row="1" Grid.Column="1" Margin="5" Background="#333" Padding="10" CornerRadius="5">
                 <StackPanel>
                     <TextBlock Text="📦 Zdobyte Przedmioty" FontSize="16" FontWeight="Bold" Margin="0 0 0 5"/>
-                    <!-- Formatowane ręcznie -->
-                    <ItemsControl ItemsSource="{Binding FormattedItemList}">
+                    <ItemsControl ItemsSource="{Binding ItemList}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate>
-                                <TextBlock Text="{Binding}" FontFamily="Consolas" TextAlignment="Left"/>
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="40" />
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="80" />
+                                    </Grid.ColumnDefinitions>
+                                    <TextBlock Grid.Column="0" Text="{Binding Name}" TextWrapping="Wrap"/>
+                                    <TextBlock Grid.Column="1" Text=" * " HorizontalAlignment="Center"/>
+                                    <TextBlock Grid.Column="2" Text="{Binding Quantity}" HorizontalAlignment="Right"/>
+                                    <TextBlock Grid.Column="3" Text=" = " HorizontalAlignment="Center"/>
+                                    <TextBlock Grid.Column="4" Text="{Binding TotalPrice, StringFormat=N0}" HorizontalAlignment="Right"/>
+                                </Grid>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
-                    <TextBlock Text="{Binding ItemSumFormatted}" FontWeight="Bold" Margin="0 5 0 0" FontFamily="Consolas"/>
+                    <Grid Margin="0 5 0 0">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock Text="Razem:" FontWeight="Bold" Grid.Column="0" />
+                        <TextBlock Text="{Binding ItemSumFormatted}" FontWeight="Bold" Grid.Column="1" HorizontalAlignment="Right"/>
+                    </Grid>
                 </StackPanel>
             </Border>
         </Grid>


### PR DESCRIPTION
## Summary
- change SummaryPanel to show item lists with columns
- provide object lists in SummaryViewModel instead of formatted strings
- add `TotalPrice` property to DropSummaryDetailed

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c4f0b01908329be4998f0d3671346