### PR TITLE
HUD context menu and movement

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -6,7 +6,7 @@ namespace BrokenHelper
 {
     public partial class App : Application
     {
-        private TrayIcon? _tray;
+        private HudWindow? _hud;
 
         protected override void OnStartup(StartupEventArgs e)
         {
@@ -17,12 +17,14 @@ namespace BrokenHelper
 
             //StatsService.RecalculateDropPrices();
 
-            _tray = new TrayIcon();
+            var player = StatsService.GetDefaultPlayerName();
+            _hud = new HudWindow(player);
+            _hud.Show();
         }
 
         protected override void OnExit(ExitEventArgs e)
         {
-            _tray?.Dispose();
+            _hud?.Close();
             base.OnExit(e);
         }
     }

--- a/Views/HudWindow.xaml
+++ b/Views/HudWindow.xaml
@@ -3,7 +3,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         Width="220" Height="180" WindowStyle="None" Topmost="True"
         AllowsTransparency="True" Background="Transparent">
-    <Border Background="#A01E1E1E" Padding="5">
+    <Border x:Name="rootBorder" Background="#A01E1E1E" Padding="5">
         <StackPanel x:Name="container" />
     </Border>
 </Window>

--- a/Views/HudWindow.xaml.cs
+++ b/Views/HudWindow.xaml.cs
@@ -2,6 +2,7 @@ using System;
 using System.Globalization;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Threading;
 
@@ -11,6 +12,10 @@ namespace BrokenHelper
     {
         private readonly DispatcherTimer _timer;
         private readonly string _playerName;
+        private PacketListener? _listener;
+        private FightsDashboardWindow? _fightsWindow;
+        private InstancesDashboardWindow? _instancesWindow;
+        private readonly MenuItem _listenMenuItem;
 
         private TextBlock _fightExpValue = null!;
         private TextBlock _fightPsychoValue = null!;
@@ -29,6 +34,36 @@ namespace BrokenHelper
             InitializeComponent();
             Left = SystemParameters.WorkArea.Right - Width - 20;
             Top = (SystemParameters.WorkArea.Height - Height) / 2;
+
+            // context menu
+            var menu = new ContextMenu();
+            _listenMenuItem = new MenuItem();
+            _listenMenuItem.Click += (_, _) => ToggleListener();
+            menu.Items.Add(_listenMenuItem);
+            menu.Items.Add(new Separator());
+
+            var minimize = new MenuItem { Header = "Minimalizuj HUD" };
+            minimize.Click += (_, _) => WindowState = WindowState.Minimized;
+            menu.Items.Add(minimize);
+
+            var instances = new MenuItem { Header = "Instancje" };
+            instances.Click += (_, _) => ShowInstances();
+            menu.Items.Add(instances);
+
+            var fights = new MenuItem { Header = "Walki" };
+            fights.Click += (_, _) => ShowFights();
+            menu.Items.Add(fights);
+
+            menu.Items.Add(new Separator());
+            var exit = new MenuItem { Header = "Zako\u0144cz" };
+            exit.Click += (_, _) => Application.Current.Shutdown();
+            menu.Items.Add(exit);
+
+            rootBorder.ContextMenu = menu;
+            MouseLeftButtonDown += HudWindow_MouseLeftButtonDown;
+
+            // start listener by default
+            ToggleListener();
 
             var fightPanel = CreateHudTable();
             var instancePanel = CreateHudTable();
@@ -174,9 +209,58 @@ namespace BrokenHelper
             _instanceDurationValue.Text = "-";
         }
 
+        private void HudWindow_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+        {
+            if (Keyboard.Modifiers.HasFlag(ModifierKeys.Alt))
+            {
+                DragMove();
+            }
+        }
+
+        private void ToggleListener()
+        {
+            if (_listener == null)
+            {
+                _listener = new PacketListener();
+                _listener.Start();
+                _listenMenuItem.Header = "Wy\u0142\u0105cz nas\u0142uchiwanie";
+            }
+            else
+            {
+                _listener.Stop();
+                _listener = null;
+                _listenMenuItem.Header = "W\u0142\u0105cz nas\u0142uchiwanie";
+            }
+        }
+
+        private void ShowInstances()
+        {
+            if (_instancesWindow == null)
+            {
+                _instancesWindow = new InstancesDashboardWindow();
+                _instancesWindow.Closed += (_, _) => _instancesWindow = null;
+            }
+            _instancesWindow.Show();
+            _instancesWindow.Activate();
+        }
+
+        private void ShowFights()
+        {
+            if (_fightsWindow == null)
+            {
+                _fightsWindow = new FightsDashboardWindow();
+                _fightsWindow.Closed += (_, _) => _fightsWindow = null;
+            }
+            _fightsWindow.Show();
+            _fightsWindow.Activate();
+        }
+
         protected override void OnClosed(EventArgs e)
         {
             _timer.Stop();
+            _listener?.Stop();
+            _fightsWindow?.Close();
+            _instancesWindow?.Close();
             base.OnClosed(e);
         }
     }


### PR DESCRIPTION
## Summary
- display HUD on startup instead of tray icon
- add right-click context menu on the HUD
- include 'Minimalizuj HUD' option and listener toggle
- allow moving HUD while holding Alt

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d12c4556c8329b255a194288d1427