### PR TITLE
Persist HUD location and player name

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -25,6 +25,7 @@ namespace BrokenHelper
         protected override void OnExit(ExitEventArgs e)
         {
             _hud?.Close();
+            Preferences.Save();
             base.OnExit(e);
         }
     }

--- a/Preferences.cs
+++ b/Preferences.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using BrokenHelper.Models;
+
+namespace BrokenHelper
+{
+    public static class Preferences
+    {
+        private static readonly string Dir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "data");
+        private static readonly string FilePath = Path.Combine(Dir, "preferences.cfg");
+
+        private static readonly Dictionary<string, string> Values = new(StringComparer.OrdinalIgnoreCase);
+
+        static Preferences()
+        {
+            Load();
+        }
+
+        private static void Load()
+        {
+            if (!File.Exists(FilePath))
+                return;
+
+            foreach (var line in File.ReadAllLines(FilePath))
+            {
+                var trimmed = line.Trim();
+                if (trimmed.StartsWith('#') || string.IsNullOrWhiteSpace(trimmed))
+                    continue;
+
+                var parts = trimmed.Split('=', 2);
+                if (parts.Length == 2)
+                    Values[parts[0].Trim()] = parts[1].Trim();
+            }
+        }
+
+        public static void Save()
+        {
+            Directory.CreateDirectory(Dir);
+            var lines = Values.Select(kv => $"{kv.Key}={kv.Value}");
+            File.WriteAllLines(FilePath, lines);
+        }
+
+        public static string? Get(string key)
+        {
+            Values.TryGetValue(key, out var value);
+            return value;
+        }
+
+        public static void Set(string key, string value)
+        {
+            Values[key] = value;
+        }
+
+        public static int? GetInt(string key)
+        {
+            if (Values.TryGetValue(key, out var value) && int.TryParse(value, out var result))
+                return result;
+            return null;
+        }
+
+        public static void SetInt(string key, int value)
+        {
+            Values[key] = value.ToString();
+        }
+
+        public static string PlayerName
+        {
+            get
+            {
+                var name = Get("playername");
+                if (!string.IsNullOrWhiteSpace(name))
+                    return name;
+
+                using var ctx = new GameDbContext();
+                name = ctx.Players.FirstOrDefault()?.Name ?? string.Empty;
+                if (!string.IsNullOrWhiteSpace(name))
+                    Set("playername", name);
+                return name;
+            }
+            set => Set("playername", value);
+        }
+    }
+}
+

--- a/StatsService.cs
+++ b/StatsService.cs
@@ -310,7 +310,7 @@ namespace BrokenHelper
 
         public static string GetDefaultPlayerName()
         {
-            return "Sign";
+            return Preferences.PlayerName;
         }
 
         public static FightsSummary? GetLastFightSummary(string playerName)

--- a/Views/FightsDashboardWindow.xaml.cs
+++ b/Views/FightsDashboardWindow.xaml.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
-using BrokenHelper.Models;
 
 namespace BrokenHelper
 {
@@ -14,10 +13,9 @@ namespace BrokenHelper
             Loaded += (_, _) => RefreshData();
         }
 
-        private string GetPlayerName()
+        private static string GetPlayerName()
         {
-            using var ctx = new GameDbContext();
-            return ctx.Players.FirstOrDefault()?.Name ?? string.Empty;
+            return StatsService.GetDefaultPlayerName();
         }
 
         private void RefreshData()

--- a/Views/HudWindow.xaml.cs
+++ b/Views/HudWindow.xaml.cs
@@ -32,8 +32,18 @@ namespace BrokenHelper
         {
             _playerName = playerName;
             InitializeComponent();
-            Left = SystemParameters.WorkArea.Right - Width - 20;
-            Top = (SystemParameters.WorkArea.Height - Height) / 2;
+            var left = Preferences.GetInt("hud_left");
+            var top = Preferences.GetInt("hud_top");
+            if (left.HasValue && top.HasValue)
+            {
+                Left = left.Value;
+                Top = top.Value;
+            }
+            else
+            {
+                Left = SystemParameters.WorkArea.Right - Width - 20;
+                Top = (SystemParameters.WorkArea.Height - Height) / 2;
+            }
 
             // context menu
             var menu = new ContextMenu();
@@ -257,6 +267,9 @@ namespace BrokenHelper
 
         protected override void OnClosed(EventArgs e)
         {
+            Preferences.SetInt("hud_left", (int)Left);
+            Preferences.SetInt("hud_top", (int)Top);
+            Preferences.Save();
             _timer.Stop();
             _listener?.Stop();
             _fightsWindow?.Close();

--- a/Views/InstancesDashboardWindow.xaml.cs
+++ b/Views/InstancesDashboardWindow.xaml.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Linq;
 using System.Windows;
-using BrokenHelper.Models;
 
 namespace BrokenHelper
 {
@@ -13,10 +12,9 @@ namespace BrokenHelper
             Loaded += (_, _) => RefreshData();
         }
 
-        private string GetPlayerName()
+        private static string GetPlayerName()
         {
-            using var ctx = new GameDbContext();
-            return ctx.Players.FirstOrDefault()?.Name ?? string.Empty;
+            return StatsService.GetDefaultPlayerName();
         }
 
         private void RefreshData()


### PR DESCRIPTION
## Summary
- keep a preferences file in the `data` directory
- load default player from `preferences.cfg`
- restore HUD window position from preferences
- save HUD position and preferences on exit
- read player from preferences in dashboards

## Testing
- `dotnet build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685d150a10cc8329b1d4b79cdad63b6e