### PR TITLE
Add manual packet input

### DIFF
--- a/ManualPacketProcessor.cs
+++ b/ManualPacketProcessor.cs
@@ -1,0 +1,50 @@
+using System;
+using BrokenHelper.PacketHandlers;
+
+namespace BrokenHelper
+{
+    internal static class ManualPacketProcessor
+    {
+        private static readonly InstanceHandler _instanceHandler = new();
+        private static readonly FightHandler _fightHandler = new(_instanceHandler);
+
+        public static void Process(string prefix, string rest)
+        {
+            using (var context = new Models.GameDbContext())
+            {
+                _instanceHandler.LoadOpenInstance(context);
+            }
+
+            rest = rest.Replace("%20", " ");
+
+            if (prefix == "1;118;")
+            {
+                SafeHandle(() => _instanceHandler.HandleInstanceMessage(rest), prefix);
+            }
+            else if (prefix == "3;19;")
+            {
+                SafeHandle(() => _fightHandler.HandleFightMessage(rest), prefix);
+            }
+            else if (prefix == "36;0;")
+            {
+                SafeHandle(() => PriceHandler.HandleItemPriceMessage(rest), prefix);
+            }
+            else if (prefix == "50;0;")
+            {
+                SafeHandle(() => PriceHandler.HandleArtifactPriceMessage(rest), prefix);
+            }
+        }
+
+        private static void SafeHandle(Action action, string prefix)
+        {
+            try
+            {
+                action();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error handling packet {prefix}: {ex.Message}");
+            }
+        }
+    }
+}

--- a/Views/HudWindow.xaml.cs
+++ b/Views/HudWindow.xaml.cs
@@ -64,6 +64,10 @@ namespace BrokenHelper
             fights.Click += (_, _) => ShowFights();
             menu.Items.Add(fights);
 
+            var manual = new MenuItem { Header = "Ręczne wprowadzanie pakietu" };
+            manual.Click += (_, _) => ShowManualPacketWindow();
+            menu.Items.Add(manual);
+
             menu.Items.Add(new Separator());
             var exit = new MenuItem { Header = "Zako\u0144cz" };
             exit.Click += (_, _) => Application.Current.Shutdown();
@@ -263,6 +267,15 @@ namespace BrokenHelper
             }
             _fightsWindow.Show();
             _fightsWindow.Activate();
+        }
+
+        private void ShowManualPacketWindow()
+        {
+            var window = new ManualPacketWindow { Owner = this };
+            if (window.ShowDialog() == true)
+            {
+                ManualPacketProcessor.Process(window.Prefix, window.Message);
+            }
         }
 
         protected override void OnClosed(EventArgs e)

--- a/Views/ManualPacketWindow.xaml
+++ b/Views/ManualPacketWindow.xaml
@@ -1,0 +1,28 @@
+<Window x:Class="BrokenHelper.ManualPacketWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Ręczne wprowadzanie pakietu" Height="260" Width="350" WindowStartupLocation="CenterOwner">
+    <Grid Margin="10">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+        <Label Content="Prefiks:" Grid.Row="0" Grid.Column="0" Margin="0,0,5,5" />
+        <ComboBox x:Name="prefixBox" Grid.Row="0" Grid.Column="1" Margin="0,0,0,5" SelectedIndex="0" >
+            <ComboBoxItem Content="1;118;" />
+            <ComboBoxItem Content="3;19;" />
+            <ComboBoxItem Content="36;0;" />
+            <ComboBoxItem Content="50;0;" />
+        </ComboBox>
+        <TextBox x:Name="messageBox" Grid.Row="1" Grid.ColumnSpan="2" AcceptsReturn="True" VerticalScrollBarVisibility="Auto" />
+        <StackPanel Orientation="Horizontal" Grid.Row="2" Grid.ColumnSpan="2" HorizontalAlignment="Right" Margin="0,10,0,0">
+            <Button Content="Wyślij" Width="80" Margin="0,0,5,0" Click="Send_Click"/>
+            <Button Content="Anuluj" Width="80" Click="Cancel_Click"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Views/ManualPacketWindow.xaml.cs
+++ b/Views/ManualPacketWindow.xaml.cs
@@ -1,0 +1,26 @@
+using System.Windows;
+using System.Windows.Controls;
+
+namespace BrokenHelper
+{
+    public partial class ManualPacketWindow : Window
+    {
+        public string Prefix => (prefixBox.SelectedItem as ComboBoxItem)?.Content?.ToString() ?? string.Empty;
+        public string Message => messageBox.Text;
+
+        public ManualPacketWindow()
+        {
+            InitializeComponent();
+        }
+
+        private void Send_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = true;
+        }
+
+        private void Cancel_Click(object sender, RoutedEventArgs e)
+        {
+            DialogResult = false;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add menu item in HUD to manually input packets
- implement `ManualPacketWindow` for entering prefix and data
- add `ManualPacketProcessor` to reuse existing packet handlers

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d2222878083299e924e4eb9da25ec