### PR TITLE
Fix tooltip border

### DIFF
--- a/Views/HudWindow.xaml.cs
+++ b/Views/HudWindow.xaml.cs
@@ -254,12 +254,20 @@ namespace BrokenHelper
                 sb.AppendLine();
             }
 
-            block.ToolTip = new TextBlock
+            var text = new TextBlock
             {
                 Text = sb.ToString().TrimEnd(),
                 FontFamily = new FontFamily("Consolas"),
                 Background = Brushes.Black,
                 Foreground = Brushes.White
+            };
+
+            block.ToolTip = new ToolTip
+            {
+                BorderThickness = new Thickness(0),
+                Background = Brushes.Black,
+                Foreground = Brushes.White,
+                Content = text
             };
         }
 


### PR DESCRIPTION
## Summary
- remove default tooltip border by customizing ToolTip object

## Testing
- `dotnet build BrokenHelper.csproj -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d31352f4c8329991e15a43fbe4af7