### PR TITLE
Fix thousand separators

### DIFF
--- a/SummaryViewModel.cs
+++ b/SummaryViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 
 namespace BrokenHelper
@@ -22,9 +23,14 @@ namespace BrokenHelper
         public int ArtifactSum { get; private set; }
         public int ItemSum { get; private set; }
 
-        public string EquipmentSumFormatted => EquipmentSum.ToString("N0").Replace(',', ' ');
-        public string ArtifactSumFormatted => ArtifactSum.ToString("N0").Replace(',', ' ');
-        public string ItemSumFormatted => ItemSum.ToString("N0").Replace(',', ' ');
+        private static readonly NumberFormatInfo _nfi = new NumberFormatInfo
+        {
+            NumberGroupSeparator = " "
+        };
+
+        public string EquipmentSumFormatted => EquipmentSum.ToString("N0", _nfi);
+        public string ArtifactSumFormatted => ArtifactSum.ToString("N0", _nfi);
+        public string ItemSumFormatted => ItemSum.ToString("N0", _nfi);
 
         public void LoadData(List<DropSummaryDetailed> drops)
         {

--- a/ThousandsSeparatorConverter.cs
+++ b/ThousandsSeparatorConverter.cs
@@ -12,7 +12,11 @@ namespace BrokenHelper
                 return null;
 
             if (value is IFormattable formattable)
-                return formattable.ToString("N0", CultureInfo.InvariantCulture);
+            {
+                var nfi = (NumberFormatInfo)CultureInfo.InvariantCulture.NumberFormat.Clone();
+                nfi.NumberGroupSeparator = " ";
+                return formattable.ToString("N0", nfi);
+            }
 
             return value.ToString();
         }

--- a/Views/HudWindow.xaml.cs
+++ b/Views/HudWindow.xaml.cs
@@ -163,9 +163,14 @@ namespace BrokenHelper
             _instanceDurationValue = AddRow(grid, "Czas:");
         }
 
+        private static readonly NumberFormatInfo _nfi = new NumberFormatInfo
+        {
+            NumberGroupSeparator = " "
+        };
+
         private static string FormatNumber(int value)
         {
-            return value.ToString("N0", CultureInfo.InvariantCulture).Replace(',', ' ');
+            return value.ToString("N0", _nfi);
         }
 
         private void UpdateData()

--- a/Views/SummaryPanel.xaml
+++ b/Views/SummaryPanel.xaml
@@ -75,9 +75,9 @@
                                     <TextBlock Grid.Column="0" Text="{Binding Name}" TextWrapping="Wrap"/>
                                     <TextBlock Grid.Column="1" Text="{Binding Quantity}" HorizontalAlignment="Right"/>
                                     <TextBlock Grid.Column="2" Text=" * " HorizontalAlignment="Center"/>
-                                    <TextBlock Grid.Column="3" Text="{Binding UnitPrice, StringFormat=N0}" HorizontalAlignment="Right"/>
+                                    <TextBlock Grid.Column="3" Text="{Binding UnitPrice, Converter={StaticResource Sep}}" HorizontalAlignment="Right"/>
                                     <TextBlock Grid.Column="4" Text=" = " HorizontalAlignment="Center"/>
-                                    <TextBlock Grid.Column="5" Text="{Binding TotalPrice, StringFormat=N0}" HorizontalAlignment="Right"/>
+                                    <TextBlock Grid.Column="5" Text="{Binding TotalPrice, Converter={StaticResource Sep}}" HorizontalAlignment="Right"/>
                                 </Grid>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
@@ -112,9 +112,9 @@
                                     <TextBlock Grid.Column="0" Text="{Binding Name}" TextWrapping="Wrap"/>
                                     <TextBlock Grid.Column="1" Text="{Binding Quantity}" HorizontalAlignment="Right"/>
                                     <TextBlock Grid.Column="2" Text=" * " HorizontalAlignment="Center"/>
-                                    <TextBlock Grid.Column="3" Text="{Binding UnitPrice, StringFormat=N0}" HorizontalAlignment="Right"/>
+                                    <TextBlock Grid.Column="3" Text="{Binding UnitPrice, Converter={StaticResource Sep}}" HorizontalAlignment="Right"/>
                                     <TextBlock Grid.Column="4" Text=" = " HorizontalAlignment="Center"/>
-                                    <TextBlock Grid.Column="5" Text="{Binding TotalPrice, StringFormat=N0}" HorizontalAlignment="Right"/>
+                                    <TextBlock Grid.Column="5" Text="{Binding TotalPrice, Converter={StaticResource Sep}}" HorizontalAlignment="Right"/>
                                 </Grid>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
@@ -149,9 +149,9 @@
                                     <TextBlock Grid.Column="0" Text="{Binding Name}" TextWrapping="Wrap"/>
                                     <TextBlock Grid.Column="1" Text="{Binding Quantity}" HorizontalAlignment="Right"/>
                                     <TextBlock Grid.Column="2" Text=" * " HorizontalAlignment="Center"/>
-                                    <TextBlock Grid.Column="3" Text="{Binding UnitPrice, StringFormat=N0}" HorizontalAlignment="Right"/>
+                                    <TextBlock Grid.Column="3" Text="{Binding UnitPrice, Converter={StaticResource Sep}}" HorizontalAlignment="Right"/>
                                     <TextBlock Grid.Column="4" Text=" = " HorizontalAlignment="Center"/>
-                                    <TextBlock Grid.Column="5" Text="{Binding TotalPrice, StringFormat=N0}" HorizontalAlignment="Right"/>
+                                    <TextBlock Grid.Column="5" Text="{Binding TotalPrice, Converter={StaticResource Sep}}" HorizontalAlignment="Right"/>
                                 </Grid>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>


### PR DESCRIPTION
## Summary
- format numbers with a space as the thousands separator everywhere
- update HUD number formatter
- use converter in summary panel listings

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d339373788329be683b4742607b1e