### PR TITLE
Add timestamp selector for manual packet input

### DIFF
--- a/ManualPacketProcessor.cs
+++ b/ManualPacketProcessor.cs
@@ -8,7 +8,9 @@ namespace BrokenHelper
         private static readonly InstanceHandler _instanceHandler = new();
         private static readonly FightHandler _fightHandler = new(_instanceHandler);
 
-        public static void Process(string prefix, string rest)
+        public static void Process(string prefix, string rest) => Process(prefix, rest, DateTime.Now);
+
+        public static void Process(string prefix, string rest, DateTime time)
         {
             using (var context = new Models.GameDbContext())
             {
@@ -19,11 +21,11 @@ namespace BrokenHelper
 
             if (prefix == "1;118;")
             {
-                SafeHandle(() => _instanceHandler.HandleInstanceMessage(rest), prefix);
+                SafeHandle(() => _instanceHandler.HandleInstanceMessage(rest, time), prefix);
             }
             else if (prefix == "3;19;")
             {
-                SafeHandle(() => _fightHandler.HandleFightMessage(rest), prefix);
+                SafeHandle(() => _fightHandler.HandleFightMessage(rest, time), prefix);
             }
             else if (prefix == "36;0;")
             {

--- a/PacketHandlers/FightHandler.cs
+++ b/PacketHandlers/FightHandler.cs
@@ -13,11 +13,11 @@ namespace BrokenHelper.PacketHandlers
             _instanceHandler = instanceHandler;
         }
 
-        public void HandleFightMessage(string message)
+        public void HandleFightMessage(string message, DateTime? time = null)
         {
             using var context = new Models.GameDbContext();
 
-            var fightTime = DateTime.Now;
+            var fightTime = time ?? DateTime.Now;
 
             var activeInstance = context.Instances
                 .FirstOrDefault(i => i.EndTime == null && i.StartTime <= fightTime);

--- a/PacketHandlers/InstanceHandler.cs
+++ b/PacketHandlers/InstanceHandler.cs
@@ -21,7 +21,7 @@ namespace BrokenHelper.PacketHandlers
             }
         }
 
-        public void HandleInstanceMessage(string message)
+        public void HandleInstanceMessage(string message, DateTime? time = null)
         {
             var parts = message.Split("[$]", StringSplitOptions.None);
             if (parts.Length <= 9)
@@ -36,7 +36,7 @@ namespace BrokenHelper.PacketHandlers
             if (context.Instances.Any(i => i.PublicId == publicId))
                 return;
 
-            var startTime = DateTime.Now;
+            var startTime = time ?? DateTime.Now;
 
             var openInstances = context.Instances.Where(i => i.EndTime == null).ToList();
             foreach (var inst in openInstances)

--- a/Views/HudWindow.xaml.cs
+++ b/Views/HudWindow.xaml.cs
@@ -322,7 +322,7 @@ namespace BrokenHelper
             var window = new ManualPacketWindow { Owner = this };
             if (window.ShowDialog() == true)
             {
-                ManualPacketProcessor.Process(window.Prefix, window.Message);
+                ManualPacketProcessor.Process(window.Prefix, window.Message, window.Time);
             }
         }
 

--- a/Views/ManualPacketWindow.xaml
+++ b/Views/ManualPacketWindow.xaml
@@ -5,6 +5,7 @@
     <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
@@ -19,8 +20,10 @@
             <ComboBoxItem Content="36;0;" />
             <ComboBoxItem Content="50;0;" />
         </ComboBox>
-        <TextBox x:Name="messageBox" Grid.Row="1" Grid.ColumnSpan="2" AcceptsReturn="True" VerticalScrollBarVisibility="Auto" />
-        <StackPanel Orientation="Horizontal" Grid.Row="2" Grid.ColumnSpan="2" HorizontalAlignment="Right" Margin="0,10,0,0">
+        <Label Content="Czas:" Grid.Row="1" Grid.Column="0" Margin="0,0,5,5" />
+        <DatePicker x:Name="timePicker" Grid.Row="1" Grid.Column="1" Margin="0,0,0,5" />
+        <TextBox x:Name="messageBox" Grid.Row="2" Grid.ColumnSpan="2" AcceptsReturn="True" VerticalScrollBarVisibility="Auto" />
+        <StackPanel Orientation="Horizontal" Grid.Row="3" Grid.ColumnSpan="2" HorizontalAlignment="Right" Margin="0,10,0,0">
             <Button Content="Wyślij" Width="80" Margin="0,0,5,0" Click="Send_Click"/>
             <Button Content="Anuluj" Width="80" Click="Cancel_Click"/>
         </StackPanel>

--- a/Views/ManualPacketWindow.xaml.cs
+++ b/Views/ManualPacketWindow.xaml.cs
@@ -5,12 +5,16 @@ namespace BrokenHelper
 {
     public partial class ManualPacketWindow : Window
     {
+        private readonly DateTime _openTime;
         public string Prefix => (prefixBox.SelectedItem as ComboBoxItem)?.Content?.ToString() ?? string.Empty;
         public string Message => messageBox.Text;
+        public DateTime Time => timePicker.SelectedDate ?? _openTime;
 
         public ManualPacketWindow()
         {
             InitializeComponent();
+            _openTime = DateTime.Now;
+            timePicker.SelectedDate = _openTime;
         }
 
         private void Send_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## Summary
- allow selecting packet timestamp in ManualPacketWindow
- propagate selected timestamp to ManualPacketProcessor
- pass timestamp into packet handlers so DB entries use chosen time

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d33d6882883298c78cec025ae0d8f