### PR TITLE
Fix missing System namespace

### DIFF
--- a/Views/ManualPacketWindow.xaml.cs
+++ b/Views/ManualPacketWindow.xaml.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Windows;
 using System.Windows.Controls;
 


### PR DESCRIPTION
## Summary
- add `using System` to `ManualPacketWindow` so it compiles

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d3f0753bc83299f6a24f2a033e315