### PR TITLE
Add datetime picker for manual packet processing

### DIFF
--- a/Controls/DateTimePicker.xaml
+++ b/Controls/DateTimePicker.xaml
@@ -1,0 +1,9 @@
+<UserControl x:Class="BrokenHelper.DateTimePicker"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             Height="25" Width="200">
+    <StackPanel Orientation="Horizontal">
+        <DatePicker x:Name="datePart" Width="120" SelectedDateChanged="DatePart_SelectedDateChanged"/>
+        <TextBox x:Name="timePart" Width="70" Margin="5,0,0,0" TextChanged="TimePart_TextChanged"/>
+    </StackPanel>
+</UserControl>

--- a/Controls/DateTimePicker.xaml.cs
+++ b/Controls/DateTimePicker.xaml.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace BrokenHelper
+{
+    public partial class DateTimePicker : UserControl
+    {
+        public DateTimePicker()
+        {
+            InitializeComponent();
+        }
+
+        public DateTime Value
+        {
+            get
+            {
+                var date = datePart.SelectedDate ?? DateTime.Now.Date;
+                var time = TimeSpan.TryParse(timePart.Text, out var t) ? t : TimeSpan.Zero;
+                return date.Date + time;
+            }
+            set
+            {
+                datePart.SelectedDate = value.Date;
+                timePart.Text = value.ToString("HH:mm:ss");
+            }
+        }
+
+        private void DatePart_SelectedDateChanged(object sender, SelectionChangedEventArgs e)
+        {
+            // keep Value in sync if needed
+        }
+
+        private void TimePart_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            // keep Value in sync if needed
+        }
+    }
+}

--- a/Views/ManualPacketWindow.xaml
+++ b/Views/ManualPacketWindow.xaml
@@ -1,6 +1,7 @@
 <Window x:Class="BrokenHelper.ManualPacketWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:controls="clr-namespace:BrokenHelper"
         Title="Ręczne wprowadzanie pakietu" Height="260" Width="350" WindowStartupLocation="CenterOwner">
     <Grid Margin="10">
         <Grid.RowDefinitions>
@@ -21,7 +22,7 @@
             <ComboBoxItem Content="50;0;" />
         </ComboBox>
         <Label Content="Czas:" Grid.Row="1" Grid.Column="0" Margin="0,0,5,5" />
-        <DatePicker x:Name="timePicker" Grid.Row="1" Grid.Column="1" Margin="0,0,0,5" />
+        <controls:DateTimePicker x:Name="timePicker" Grid.Row="1" Grid.Column="1" Margin="0,0,0,5" />
         <TextBox x:Name="messageBox" Grid.Row="2" Grid.ColumnSpan="2" AcceptsReturn="True" VerticalScrollBarVisibility="Auto" />
         <StackPanel Orientation="Horizontal" Grid.Row="3" Grid.ColumnSpan="2" HorizontalAlignment="Right" Margin="0,10,0,0">
             <Button Content="Wyślij" Width="80" Margin="0,0,5,0" Click="Send_Click"/>

--- a/Views/ManualPacketWindow.xaml.cs
+++ b/Views/ManualPacketWindow.xaml.cs
@@ -9,13 +9,13 @@ namespace BrokenHelper
         private readonly DateTime _openTime;
         public string Prefix => (prefixBox.SelectedItem as ComboBoxItem)?.Content?.ToString() ?? string.Empty;
         public string Message => messageBox.Text;
-        public DateTime Time => timePicker.SelectedDate ?? _openTime;
+        public DateTime Time => timePicker.Value;
 
         public ManualPacketWindow()
         {
             InitializeComponent();
             _openTime = DateTime.Now;
-            timePicker.SelectedDate = _openTime;
+            timePicker.Value = _openTime;
         }
 
         private void Send_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## Summary
- add a simple `DateTimePicker` control that combines `DatePicker` and a time text box
- use the new `DateTimePicker` in `ManualPacketWindow`

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d403e029883298cfa9cd1224f884d