### PR TITLE
Fix fight assignment and show instance end time

### DIFF
--- a/PacketHandlers/FightHandler.cs
+++ b/PacketHandlers/FightHandler.cs
@@ -19,17 +19,21 @@ namespace BrokenHelper.PacketHandlers
 
             var fightTime = time ?? DateTime.Now;
 
-            var activeInstance = context.Instances
-                .FirstOrDefault(i => i.EndTime == null && i.StartTime <= fightTime);
-            if (activeInstance != null)
+            var instance = context.Instances
+                .FirstOrDefault(i => i.StartTime <= fightTime &&
+                    (i.EndTime == null || fightTime <= i.EndTime));
+
+            if (instance != null && instance.EndTime == null)
+            {
                 typeof(InstanceHandler)
                     .GetField("_currentInstanceId", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)!
-                    .SetValue(_instanceHandler, activeInstance.Id);
+                    .SetValue(_instanceHandler, instance.Id);
+            }
 
             var fight = new Models.FightEntity
             {
                 EndTime = fightTime,
-                InstanceId = activeInstance?.Id
+                InstanceId = instance?.Id
             };
 
             context.Fights.Add(fight);

--- a/StatsService.cs
+++ b/StatsService.cs
@@ -6,7 +6,7 @@ using Microsoft.EntityFrameworkCore;
 
 namespace BrokenHelper
 {
-    public record InstanceInfo(int Id, DateTime StartTime, string Name,
+    public record InstanceInfo(int Id, DateTime StartTime, DateTime? EndTime, string Name,
         int Difficulty, string Duration, int EarnedExp, int EarnedPsycho,
         int FoundGold, int DropValue, int FightCount);
 
@@ -78,6 +78,7 @@ namespace BrokenHelper
                 result.Add(new InstanceInfo(
                     instance.Id,
                     instance.StartTime,
+                    instance.EndTime,
                     instance.Name,
                     instance.Difficulty,
                     duration,
@@ -397,6 +398,7 @@ namespace BrokenHelper
             return new InstanceInfo(
                 instance.Id,
                 instance.StartTime,
+                instance.EndTime,
                 instance.Name,
                 instance.Difficulty,
                 duration,
@@ -442,6 +444,7 @@ namespace BrokenHelper
             return new InstanceInfo(
                 instance.Id,
                 instance.StartTime,
+                instance.EndTime,
                 instance.Name,
                 instance.Difficulty,
                 duration,

--- a/Views/InstancesDashboardWindow.xaml
+++ b/Views/InstancesDashboardWindow.xaml
@@ -19,6 +19,7 @@
             </DataGrid.Resources>
             <DataGrid.Columns>
                 <DataGridTextColumn Binding="{Binding StartTime}" Header="Start" />
+                <DataGridTextColumn Binding="{Binding EndTime}" Header="Koniec" />
                 <DataGridTextColumn Binding="{Binding Name}" Header="Nazwa" />
                 <DataGridTextColumn Binding="{Binding Difficulty}" Header="Poziom" />
                 <DataGridTextColumn Binding="{Binding Duration}" Header="Czas" />


### PR DESCRIPTION
## Summary
- handle manual fights when instance already closed
- show instance end time in instance list

## Testing
- `dotnet test` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685d425958408329bc214a267a1ba6e9