### PR TITLE
Add sound notification for fight round

### DIFF
--- a/Helpers/SoundHelper.cs
+++ b/Helpers/SoundHelper.cs
@@ -1,0 +1,19 @@
+using System.Media;
+
+namespace BrokenHelper.Helpers
+{
+    internal static class SoundHelper
+    {
+        public static void PlayBeep()
+        {
+            try
+            {
+                SystemSounds.Beep.Play();
+            }
+            catch
+            {
+                // ignore sound errors
+            }
+        }
+    }
+}

--- a/ManualPacketProcessor.cs
+++ b/ManualPacketProcessor.cs
@@ -1,5 +1,6 @@
 using System;
 using BrokenHelper.PacketHandlers;
+using BrokenHelper.Helpers;
 
 namespace BrokenHelper
 {
@@ -22,6 +23,11 @@ namespace BrokenHelper
             if (prefix == "1;118;")
             {
                 SafeHandle(() => _instanceHandler.HandleInstanceMessage(rest, time), prefix);
+            }
+            else if (prefix == "3;2;")
+            {
+                if (Preferences.SoundSignals)
+                    SoundHelper.PlayBeep();
             }
             else if (prefix == "3;19;")
             {

--- a/PacketListener.cs
+++ b/PacketListener.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using BrokenHelper.Helpers;
 using BrokenHelper.PacketHandlers;
 
 namespace BrokenHelper
@@ -147,6 +148,11 @@ namespace BrokenHelper
                 if (prefix == "1;118;")
                 {
                     SafeHandle(() => _instanceHandler.HandleInstanceMessage(rest), prefix);
+                }
+                else if (prefix == "3;2;")
+                {
+                    if (Preferences.SoundSignals)
+                        SoundHelper.PlayBeep();
                 }
                 else if (prefix == "3;19;")
                 {

--- a/Preferences.cs
+++ b/Preferences.cs
@@ -81,6 +81,12 @@ namespace BrokenHelper
             }
             set => Set("playername", value);
         }
+
+        public static bool SoundSignals
+        {
+            get => Get("sound_signals") == "1";
+            set => Set("sound_signals", value ? "1" : "0");
+        }
     }
 }
 

--- a/Views/HudWindow.xaml.cs
+++ b/Views/HudWindow.xaml.cs
@@ -74,6 +74,19 @@ namespace BrokenHelper
             manual.Click += (_, _) => ShowManualPacketWindow();
             menu.Items.Add(manual);
 
+            var sounds = new MenuItem
+            {
+                Header = "Sygnały dźwiękowe",
+                IsCheckable = true,
+                IsChecked = Preferences.SoundSignals
+            };
+            sounds.Click += (_, _) =>
+            {
+                Preferences.SoundSignals = sounds.IsChecked;
+                Preferences.Save();
+            };
+            menu.Items.Add(sounds);
+
             menu.Items.Add(new Separator());
             var exit = new MenuItem { Header = "Zako\u0144cz" };
             exit.Click += (_, _) => Application.Current.Shutdown();


### PR DESCRIPTION
## Summary
- implement `SoundHelper.PlayBeep` for short beep sound
- allow enabling sound signals via new `Preferences.SoundSignals`
- add "Sygnały dźwiękowe" checkbox in HUD context menu
- play beep when packet `3;2;` is received

## Testing
- `dotnet build -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d5df4c1e083299f87eabb0c0a5942