### PR TITLE
Move boss definitions to config file

### DIFF
--- a/PacketHandlers/FightHandler.cs
+++ b/PacketHandlers/FightHandler.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using BrokenHelper;
 
 namespace BrokenHelper.PacketHandlers
 {
@@ -269,10 +270,10 @@ namespace BrokenHelper.PacketHandlers
                     if (name.Contains('"'))
                     {
                         if (ornamentField.HasValue && quality.HasValue &&
-                            ornamentField.Value >= 0 && ornamentField.Value < PacketListener.QuoteItemCoefficients.GetLength(0) &&
-                            quality.Value >= 7 && quality.Value <= PacketListener.QuoteItemCoefficients.GetLength(1))
+                            ornamentField.Value >= 0 && ornamentField.Value < Preferences.QuoteItemCoefficients.GetLength(0) &&
+                            quality.Value >= 7 && quality.Value <= Preferences.QuoteItemCoefficients.GetLength(1))
                         {
-                            int coef = PacketListener.QuoteItemCoefficients[ornamentField.Value, quality.Value - 1];
+                            int coef = Preferences.QuoteItemCoefficients[ornamentField.Value, quality.Value - 1];
                             var basePrice = quality.Value >= 7 ? shardPrice : essencePrice;
                             valueField = coef * basePrice;
                         }

--- a/PacketHandlers/InstanceHandler.cs
+++ b/PacketHandlers/InstanceHandler.cs
@@ -1,13 +1,14 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using BrokenHelper;
 
 namespace BrokenHelper.PacketHandlers
 {
     internal class InstanceHandler
     {
         private int? _currentInstanceId;
-        private HashSet<string>[] _currentGroupProgress = PacketListener.BossGroups.Select(g => new HashSet<string>()).ToArray();
+        private HashSet<string>[] _currentGroupProgress = Preferences.BossGroups.Select(g => new HashSet<string>()).ToArray();
         private readonly Dictionary<string, int> _currentMultiKillCounts = new();
 
         public int? CurrentInstanceId => _currentInstanceId;
@@ -57,7 +58,7 @@ namespace BrokenHelper.PacketHandlers
             context.SaveChanges();
 
             _currentInstanceId = instance.Id;
-            _currentGroupProgress = PacketListener.BossGroups.Select(g => new HashSet<string>()).ToArray();
+            _currentGroupProgress = Preferences.BossGroups.Select(g => new HashSet<string>()).ToArray();
             _currentMultiKillCounts.Clear();
         }
 
@@ -68,7 +69,7 @@ namespace BrokenHelper.PacketHandlers
 
             foreach (var name in opponentNames)
             {
-                if (PacketListener.MultiKillBosses.TryGetValue(name, out var required))
+                if (Preferences.MultiKillBosses.TryGetValue(name, out var required))
                 {
                     _currentMultiKillCounts.TryGetValue(name, out var count);
                     count++;
@@ -81,12 +82,12 @@ namespace BrokenHelper.PacketHandlers
                 }
 
                 bool grouped = false;
-                for (int i = 0; i < PacketListener.BossGroups.Length; i++)
+                for (int i = 0; i < Preferences.BossGroups.Length; i++)
                 {
-                    if (PacketListener.BossGroups[i].Contains(name))
+                    if (Preferences.BossGroups[i].Contains(name))
                     {
                         _currentGroupProgress[i].Add(name);
-                        if (_currentGroupProgress[i].Count == PacketListener.BossGroups[i].Length)
+                        if (_currentGroupProgress[i].Count == Preferences.BossGroups[i].Length)
                         {
                             CloseCurrentInstance(fightTime, context);
                         }
@@ -95,7 +96,7 @@ namespace BrokenHelper.PacketHandlers
                     }
                 }
 
-                if (!grouped && PacketListener.SingleBosses.Contains(name))
+                if (!grouped && Preferences.SingleBosses.Contains(name))
                 {
                     CloseCurrentInstance(fightTime, context);
                 }
@@ -116,7 +117,7 @@ namespace BrokenHelper.PacketHandlers
 
             _currentInstanceId = null;
             _currentMultiKillCounts.Clear();
-            _currentGroupProgress = PacketListener.BossGroups.Select(g => new HashSet<string>()).ToArray();
+            _currentGroupProgress = Preferences.BossGroups.Select(g => new HashSet<string>()).ToArray();
         }
     }
 }

--- a/PacketListener.cs
+++ b/PacketListener.cs
@@ -12,44 +12,6 @@ namespace BrokenHelper
 {
     internal class PacketListener
     {
-        internal static readonly string[][] BossGroups = new[]
-        {
-            new[] { "Duch Ognia", "Duch Energii", "Duch Zimna" },
-            new[] { "Babadek", "Gregorius", "Ghadira" },
-            new[] { "Mahet", "Tarul" },
-            new[] { "Lugus", "Morana" },
-            new[] { "Fyodor", "Gmo" }
-        };
-
-        internal static readonly Dictionary<string, int> MultiKillBosses = new()
-        {
-            { "Konstrukt", 3 },
-            { "Osłabiony Konstrukt", 3 }
-        };
-
-        internal static readonly HashSet<string> SingleBosses = new(new[]
-        {
-            "Admirał Utoru", "Angwalf-Htaga", "Aqua Regis", "Bibliotekarz",
-            "Draugul", "Duch Zamku", "Garthmog", "Geomorph", "Herszt",
-            "Heurokratos", "Hvar", "Ichtion", "Ivravul", "Jaskółka",
-            "Jastrzębior", "Krzyżak", "Modliszka", "Mortus", "Nidhogg",
-            "Niedźwiedź", "Obserwator", "Ropucha", "Selena", "Sidraga",
-            "Tygrys", "Utor Komandor", "Valdarog", "Vidvar", "Vough",
-            "Wendigo", "Władca Marionetek"
-        });
-
-        internal static readonly int[,] QuoteItemCoefficients = new int[,]
-        {
-            { 4, 4, 4, 20, 20, 20, 67, 67, 67, 351, 351, 351 },
-            { 7, 7, 7, 27, 27, 27, 90, 90, 90, 585, 585, 585 },
-            { 10, 10, 10, 54, 54, 54, 180, 180, 180, 1170, 1170, 1170 },
-            { 16, 16, 16, 81, 81, 81, 270, 270, 270, 1755, 1755, 1755 },
-            { 27, 27, 27, 135, 135, 135, 450, 450, 450, 2925, 2925, 2925 },
-            { 40, 40, 40, 202, 202, 202, 675, 675, 675, 4680, 4680, 4680 },
-            { 67, 67, 67, 337, 337, 337, 1125, 1125, 1125, 7605, 7605, 7605 },
-            { 135, 135, 135, 675, 675, 675, 2250, 2250, 2250, 14625, 14625, 14625 },
-            { 337, 337, 337, 1687, 1687, 1687, 5850, 5850, 5850, 35100, 35100, 35100 }
-        };
 
         private ICaptureDevice? _device;
         private readonly List<byte> _buffer = new();

--- a/Preferences.cs
+++ b/Preferences.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.Json;
 using BrokenHelper.Models;
 
 namespace BrokenHelper
@@ -9,9 +10,62 @@ namespace BrokenHelper
     public static class Preferences
     {
         private static readonly string Dir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "data");
-        private static readonly string FilePath = Path.Combine(Dir, "preferences.cfg");
+        private static readonly string FilePath = Path.Combine(Dir, "config.cfg");
+
+        private static readonly string[][] DefaultBossGroups = new[]
+        {
+            new[] { "Duch Ognia", "Duch Energii", "Duch Zimna" },
+            new[] { "Babadek", "Gregorius", "Ghadira" },
+            new[] { "Mahet", "Tarul" },
+            new[] { "Lugus", "Morana" },
+            new[] { "Fyodor", "Gmo" }
+        };
+
+        private static readonly Dictionary<string, int> DefaultMultiKillBosses = new()
+        {
+            { "Konstrukt", 3 },
+            { "Osłabiony Konstrukt", 3 }
+        };
+
+        private static readonly string[] DefaultSingleBosses = new[]
+        {
+            "Admirał Utoru", "Angwalf-Htaga", "Aqua Regis", "Bibliotekarz",
+            "Draugul", "Duch Zamku", "Garthmog", "Geomorph", "Herszt",
+            "Heurokratos", "Hvar", "Ichtion", "Ivravul", "Jaskółka",
+            "Jastrzębior", "Krzyżak", "Modliszka", "Mortus", "Nidhogg",
+            "Niedźwiedź", "Obserwator", "Ropucha", "Selena", "Sidraga",
+            "Tygrys", "Utor Komandor", "Valdarog", "Vidvar", "Vough",
+            "Wendigo", "Władca Marionetek"
+        };
+
+        private static readonly int[,] DefaultQuoteItemCoefficients = new int[,]
+        {
+            { 4, 4, 4, 20, 20, 20, 67, 67, 67, 351, 351, 351 },
+            { 7, 7, 7, 27, 27, 27, 90, 90, 90, 585, 585, 585 },
+            { 10, 10, 10, 54, 54, 54, 180, 180, 180, 1170, 1170, 1170 },
+            { 16, 16, 16, 81, 81, 81, 270, 270, 270, 1755, 1755, 1755 },
+            { 27, 27, 27, 135, 135, 135, 450, 450, 450, 2925, 2925, 2925 },
+            { 40, 40, 40, 202, 202, 202, 675, 675, 675, 4680, 4680, 4680 },
+            { 67, 67, 67, 337, 337, 337, 1125, 1125, 1125, 7605, 7605, 7605 },
+            { 135, 135, 135, 675, 675, 675, 2250, 2250, 2250, 14625, 14625, 14625 },
+            { 337, 337, 337, 1687, 1687, 1687, 5850, 5850, 5850, 35100, 35100, 35100 }
+        };
+
+        public static string[][] BossGroups { get; private set; } = DefaultBossGroups;
+        public static Dictionary<string, int> MultiKillBosses { get; private set; } = new(DefaultMultiKillBosses);
+        public static HashSet<string> SingleBosses { get; private set; } = new(DefaultSingleBosses);
+        public static int[,] QuoteItemCoefficients { get; private set; } = DefaultQuoteItemCoefficients;
 
         private static readonly Dictionary<string, string> Values = new(StringComparer.OrdinalIgnoreCase);
+
+        private class ConfigFile
+        {
+            public Dictionary<string, string>? Values { get; set; }
+            public string[][]? BossGroups { get; set; }
+            public Dictionary<string, int>? MultiKillBosses { get; set; }
+            public string[]? SingleBosses { get; set; }
+            public int[][]? QuoteItemCoefficients { get; set; }
+        }
 
         static Preferences()
         {
@@ -23,23 +77,48 @@ namespace BrokenHelper
             if (!File.Exists(FilePath))
                 return;
 
-            foreach (var line in File.ReadAllLines(FilePath))
+            try
             {
-                var trimmed = line.Trim();
-                if (trimmed.StartsWith('#') || string.IsNullOrWhiteSpace(trimmed))
-                    continue;
-
-                var parts = trimmed.Split('=', 2);
-                if (parts.Length == 2)
-                    Values[parts[0].Trim()] = parts[1].Trim();
+                var json = File.ReadAllText(FilePath);
+                var cfg = System.Text.Json.JsonSerializer.Deserialize<ConfigFile>(json);
+                if (cfg != null)
+                {
+                    if (cfg.Values != null)
+                    {
+                        foreach (var kv in cfg.Values)
+                            Values[kv.Key] = kv.Value;
+                    }
+                    if (cfg.BossGroups != null)
+                        BossGroups = cfg.BossGroups;
+                    if (cfg.MultiKillBosses != null)
+                        MultiKillBosses = new Dictionary<string, int>(cfg.MultiKillBosses);
+                    if (cfg.SingleBosses != null)
+                        SingleBosses = new HashSet<string>(cfg.SingleBosses);
+                    if (cfg.QuoteItemCoefficients != null)
+                        QuoteItemCoefficients = ToRect(cfg.QuoteItemCoefficients);
+                }
+            }
+            catch
+            {
+                // ignore invalid config
             }
         }
 
         public static void Save()
         {
             Directory.CreateDirectory(Dir);
-            var lines = Values.Select(kv => $"{kv.Key}={kv.Value}");
-            File.WriteAllLines(FilePath, lines);
+            var cfg = new ConfigFile
+            {
+                Values = Values,
+                BossGroups = BossGroups,
+                MultiKillBosses = MultiKillBosses,
+                SingleBosses = SingleBosses.ToArray(),
+                QuoteItemCoefficients = ToJagged(QuoteItemCoefficients)
+            };
+
+            var json = System.Text.Json.JsonSerializer.Serialize(cfg,
+                new System.Text.Json.JsonSerializerOptions { WriteIndented = true });
+            File.WriteAllText(FilePath, json);
         }
 
         public static string? Get(string key)
@@ -86,6 +165,33 @@ namespace BrokenHelper
         {
             get => Get("sound_signals") == "1";
             set => Set("sound_signals", value ? "1" : "0");
+        }
+
+        private static int[][] ToJagged(int[,] rect)
+        {
+            var rows = rect.GetLength(0);
+            var cols = rect.GetLength(1);
+            var result = new int[rows][];
+            for (int i = 0; i < rows; i++)
+            {
+                result[i] = new int[cols];
+                for (int j = 0; j < cols; j++)
+                    result[i][j] = rect[i, j];
+            }
+            return result;
+        }
+
+        private static int[,] ToRect(int[][] jagged)
+        {
+            var rows = jagged.Length;
+            var cols = rows > 0 ? jagged[0].Length : 0;
+            var result = new int[rows, cols];
+            for (int i = 0; i < rows; i++)
+            {
+                for (int j = 0; j < cols; j++)
+                    result[i, j] = jagged[i][j];
+            }
+            return result;
         }
     }
 }


### PR DESCRIPTION
## Summary
- rename preferences.cfg -> config.cfg
- load config from `data/config.cfg`
- store boss groups and quote coefficients in the config file
- reference these values via `Preferences`

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d63b41e8c8329a9b05ec2a569ff8b