### PR TITLE
Add in-app log viewer

### DIFF
--- a/Logger.cs
+++ b/Logger.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BrokenHelper
+{
+    internal record LogEntry(DateTime Time, string Prefix, string Message);
+
+    internal static class Logger
+    {
+        private static readonly List<LogEntry> _entries = new();
+        public static event Action<LogEntry>? LogAdded;
+
+        public static IReadOnlyList<LogEntry> Entries
+        {
+            get { lock (_entries) { return _entries.ToList(); } }
+        }
+
+        public static void Add(string prefix, string message, DateTime time)
+        {
+            var entry = new LogEntry(time, prefix, message);
+            lock (_entries)
+            {
+                _entries.Add(entry);
+            }
+            LogAdded?.Invoke(entry);
+        }
+    }
+}

--- a/ManualPacketProcessor.cs
+++ b/ManualPacketProcessor.cs
@@ -21,6 +21,7 @@ namespace BrokenHelper
             rest = rest.Replace("%20", " ");
             var snippet = rest.Length > 60 ? rest.Substring(0, 60) : rest;
             Console.WriteLine($"{time:O} {prefix} {snippet}");
+            Logger.Add(prefix, rest, time);
 
             if (prefix == "1;118;")
             {

--- a/PacketListener.cs
+++ b/PacketListener.cs
@@ -142,6 +142,7 @@ namespace BrokenHelper
 
                 var snippet = rest.Length > 60 ? rest.Substring(0, 60) : rest;
                 Console.WriteLine($"{DateTime.Now:O} {prefix} {snippet}");
+                Logger.Add(prefix, rest, DateTime.Now);
 
                 var fileName = prefix.Replace(';', '_').TrimEnd('_') + ".txt";
                 var filePath = Path.Combine(_dataPath, fileName);

--- a/Views/HudWindow.xaml.cs
+++ b/Views/HudWindow.xaml.cs
@@ -18,6 +18,7 @@ namespace BrokenHelper
         private PacketListener? _listener;
         private FightsDashboardWindow? _fightsWindow;
         private InstancesDashboardWindow? _instancesWindow;
+        private LogsWindow? _logsWindow;
         private readonly MenuItem _listenMenuItem;
 
         private TextBlock _fightExpValue = null!;
@@ -69,6 +70,10 @@ namespace BrokenHelper
             var fights = new MenuItem { Header = "Walki" };
             fights.Click += (_, _) => ShowFights();
             menu.Items.Add(fights);
+
+            var logs = new MenuItem { Header = "Logi" };
+            logs.Click += (_, _) => ShowLogs();
+            menu.Items.Add(logs);
 
             var manual = new MenuItem { Header = "Ręczne wprowadzanie pakietu" };
             manual.Click += (_, _) => ShowManualPacketWindow();
@@ -344,6 +349,18 @@ namespace BrokenHelper
             }
         }
 
+        private void ShowLogs()
+        {
+            if (_logsWindow == null)
+            {
+                _logsWindow = new LogsWindow();
+                _logsWindow.Closed += (_, _) => _logsWindow = null;
+            }
+            _logsWindow.Owner = this;
+            _logsWindow.Show();
+            _logsWindow.Activate();
+        }
+
         protected override void OnClosed(EventArgs e)
         {
             Preferences.SetInt("hud_left", (int)Left);
@@ -353,6 +370,7 @@ namespace BrokenHelper
             _listener?.Stop();
             _fightsWindow?.Close();
             _instancesWindow?.Close();
+            _logsWindow?.Close();
             base.OnClosed(e);
         }
     }

--- a/Views/LogsWindow.xaml
+++ b/Views/LogsWindow.xaml
@@ -1,0 +1,26 @@
+<Window x:Class="BrokenHelper.LogsWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Logi" Height="400" Width="600">
+    <Grid Margin="5">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="150" />
+            <ColumnDefinition Width="*" />
+        </Grid.ColumnDefinitions>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <ListBox x:Name="prefixList" Grid.Row="0" Grid.Column="0"
+                 SelectionMode="Extended"
+                 SelectionChanged="prefixList_SelectionChanged" />
+        <RichTextBox x:Name="logBox" Grid.Row="0" Grid.Column="1" Margin="5,0,0,0"
+                     IsReadOnly="True" VerticalScrollBarVisibility="Auto"
+                     HorizontalScrollBarVisibility="Hidden"
+                     TextWrapping="NoWrap" />
+
+        <CheckBox x:Name="autoScroll" Grid.Row="1" Grid.Column="1" Margin="5,5,0,0"
+                  IsChecked="True" Content="Auto scroll" HorizontalAlignment="Right"/>
+    </Grid>
+</Window>

--- a/Views/LogsWindow.xaml.cs
+++ b/Views/LogsWindow.xaml.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Windows;
+using System.Windows.Documents;
+using System.Windows.Media;
+
+namespace BrokenHelper
+{
+    public partial class LogsWindow : Window
+    {
+        private readonly ObservableCollection<string> _prefixes = new();
+
+        public LogsWindow()
+        {
+            InitializeComponent();
+            prefixList.ItemsSource = _prefixes;
+            Logger.LogAdded += Logger_LogAdded;
+            Loaded += (_, _) => LoadInitial();
+            Closed += (_, _) => Logger.LogAdded -= Logger_LogAdded;
+        }
+
+        private void LoadInitial()
+        {
+            foreach (var entry in Logger.Entries)
+            {
+                EnsurePrefix(entry.Prefix);
+            }
+            UpdateLogs();
+        }
+
+        private void Logger_LogAdded(LogEntry entry)
+        {
+            Dispatcher.Invoke(() =>
+            {
+                EnsurePrefix(entry.Prefix);
+                if (ShouldShow(entry.Prefix))
+                {
+                    AppendEntry(entry);
+                }
+            });
+        }
+
+        private bool ShouldShow(string prefix)
+        {
+            if (prefixList.SelectedItems.Count == 0)
+                return false;
+            return prefixList.SelectedItems.Cast<string>().Contains(prefix);
+        }
+
+        private void EnsurePrefix(string prefix)
+        {
+            if (!_prefixes.Contains(prefix))
+                _prefixes.Add(prefix);
+        }
+
+        private void AppendEntry(LogEntry entry)
+        {
+            var p = new Paragraph { Margin = new Thickness(0) };
+            p.Inlines.Add(new Run(entry.Time.ToString("HH:mm:ss.fff") + " ") { Foreground = Brushes.Gray });
+            p.Inlines.Add(new Run(entry.Message));
+            logBox.Document.Blocks.Add(p);
+            if (autoScroll.IsChecked == true)
+                logBox.ScrollToEnd();
+        }
+
+        private void prefixList_SelectionChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
+        {
+            UpdateLogs();
+        }
+
+        private void UpdateLogs()
+        {
+            logBox.Document.Blocks.Clear();
+            var selected = prefixList.SelectedItems.Cast<string>().ToList();
+            if (selected.Count == 0)
+                return;
+
+            foreach (var entry in Logger.Entries.Where(l => selected.Contains(l.Prefix)))
+            {
+                AppendEntry(entry);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create a simple Logger service to keep packet logs
- log packets from `PacketListener` and `ManualPacketProcessor`
- introduce `LogsWindow` with prefix filtering and auto-scroll option
- add `Logi` entry to HUD context menu to open the log window

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d7821fb6883299c9b6359f29c5440