### PR TITLE
Handle start and end of fights

### DIFF
--- a/ManualPacketProcessor.cs
+++ b/ManualPacketProcessor.cs
@@ -31,9 +31,17 @@ namespace BrokenHelper
                 if (Preferences.SoundSignals)
                     SoundHelper.PlayBeep();
             }
+            else if (prefix == "3;1;")
+            {
+                SafeHandle(() => _fightHandler.HandleFightStart(time), prefix);
+            }
             else if (prefix == "3;19;")
             {
-                SafeHandle(() => _fightHandler.HandleFightMessage(rest, time), prefix);
+                SafeHandle(() => _fightHandler.HandleFightSummary(rest, time), prefix);
+            }
+            else if (prefix == "6;43;")
+            {
+                SafeHandle(() => _fightHandler.HandleFightEnd(time), prefix);
             }
             else if (prefix == "36;0;")
             {

--- a/Models/FightEntity.cs
+++ b/Models/FightEntity.cs
@@ -6,6 +6,7 @@ namespace BrokenHelper.Models
     public class FightEntity
     {
         public int Id { get; set; }
+        public DateTime StartTime { get; set; }
         public DateTime EndTime { get; set; }
 
         public int? InstanceId { get; set; }

--- a/PacketListener.cs
+++ b/PacketListener.cs
@@ -157,9 +157,17 @@ namespace BrokenHelper
                     if (Preferences.SoundSignals)
                         SoundHelper.PlayBeep();
                 }
+                else if (prefix == "3;1;")
+                {
+                    SafeHandle(() => _fightHandler.HandleFightStart(), prefix);
+                }
                 else if (prefix == "3;19;")
                 {
-                    SafeHandle(() => _fightHandler.HandleFightMessage(rest), prefix);
+                    SafeHandle(() => _fightHandler.HandleFightSummary(rest), prefix);
+                }
+                else if (prefix == "6;43;")
+                {
+                    SafeHandle(() => _fightHandler.HandleFightEnd(), prefix);
                 }
                 else if (prefix == "36;0;")
                 {

--- a/Views/ManualPacketWindow.xaml
+++ b/Views/ManualPacketWindow.xaml
@@ -17,7 +17,9 @@
         <Label Content="Prefiks:" Grid.Row="0" Grid.Column="0" Margin="0,0,5,5" />
         <ComboBox x:Name="prefixBox" Grid.Row="0" Grid.Column="1" Margin="0,0,0,5" SelectedIndex="0" >
             <ComboBoxItem Content="1;118;" />
+            <ComboBoxItem Content="3;1;" />
             <ComboBoxItem Content="3;19;" />
+            <ComboBoxItem Content="6;43;" />
             <ComboBoxItem Content="36;0;" />
             <ComboBoxItem Content="50;0;" />
         </ComboBox>


### PR DESCRIPTION
## Summary
- extend `FightEntity` with `StartTime`
- create separate fight start, summary and end handlers
- defer instance closing until `6;43;` packet
- support new packet types in listener and manual packet entry

## Testing
- `dotnet build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685d9a1548808329a93ca348c5d7eabe