### PR TITLE
Fix warnings and refresh HUD on fights

### DIFF
--- a/GameEvents.cs
+++ b/GameEvents.cs
@@ -1,0 +1,20 @@
+using System;
+
+namespace BrokenHelper
+{
+    internal static class GameEvents
+    {
+        public static event Action? FightStarted;
+        public static event Action? FightSummary;
+
+        internal static void OnFightStarted()
+        {
+            FightStarted?.Invoke();
+        }
+
+        internal static void OnFightSummary()
+        {
+            FightSummary?.Invoke();
+        }
+    }
+}

--- a/ManualPacketProcessor.cs
+++ b/ManualPacketProcessor.cs
@@ -61,7 +61,7 @@ namespace BrokenHelper
             {
                 action();
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 // ignore or log elsewhere
             }

--- a/Models/FightEntity.cs
+++ b/Models/FightEntity.cs
@@ -7,7 +7,7 @@ namespace BrokenHelper.Models
     {
         public int Id { get; set; }
         public DateTime StartTime { get; set; }
-        public DateTime EndTime { get; set; }
+        public DateTime? EndTime { get; set; }
 
         public int? InstanceId { get; set; }
         public InstanceEntity? Instance { get; set; }

--- a/PacketHandlers/FightHandler.cs
+++ b/PacketHandlers/FightHandler.cs
@@ -41,6 +41,8 @@ namespace BrokenHelper.PacketHandlers
             context.SaveChanges();
 
             _currentFightId = fight.Id;
+
+            GameEvents.OnFightStarted();
         }
 
         public void HandleFightSummary(string message, DateTime? time = null)
@@ -101,6 +103,8 @@ namespace BrokenHelper.PacketHandlers
 
             context.SaveChanges();
             _instanceHandler.CheckInstanceCompletion(opponentNames, fightTime, context);
+
+            GameEvents.OnFightSummary();
         }
 
         public void HandleFightEnd(DateTime? time = null)

--- a/StatsService.cs
+++ b/StatsService.cs
@@ -105,7 +105,7 @@ namespace BrokenHelper
                 .Include(f => f.Players).ThenInclude(fp => fp.Player)
                 .Include(f => f.Players).ThenInclude(fp => fp.Drops)
                 .Include(f => f.Opponents).ThenInclude(o => o.OpponentType)
-                .Where(f => f.EndTime >= from && f.EndTime <= to);
+                .Where(f => f.EndTime != null && f.EndTime >= from && f.EndTime <= to);
 
             if (onlyWithoutInstance)
             {
@@ -128,7 +128,7 @@ namespace BrokenHelper
                 {
                     result.Add(new FightInfo(
                         fight.Id,
-                        fight.EndTime,
+                        fight.EndTime ?? fight.StartTime,
                         players,
                         opponents,
                         0,
@@ -151,7 +151,7 @@ namespace BrokenHelper
 
                 result.Add(new FightInfo(
                     fight.Id,
-                    fight.EndTime,
+                    fight.EndTime ?? fight.StartTime,
                     players,
                     opponents,
                     my.Exp,
@@ -195,7 +195,7 @@ namespace BrokenHelper
                 {
                     result.Add(new FightInfo(
                         fight.Id,
-                        fight.EndTime,
+                        fight.EndTime ?? fight.StartTime,
                         players,
                         opponents,
                         0,
@@ -218,7 +218,7 @@ namespace BrokenHelper
 
                 result.Add(new FightInfo(
                     fight.Id,
-                    fight.EndTime,
+                    fight.EndTime ?? fight.StartTime,
                     players,
                     opponents,
                     my.Exp,

--- a/Views/HudWindow.xaml.cs
+++ b/Views/HudWindow.xaml.cs
@@ -35,6 +35,20 @@ namespace BrokenHelper
         private List<DropSummaryDetailed> _fightDrops = new();
         private List<DropSummaryDetailed> _instanceDrops = new();
 
+        private void OnFightStarted()
+        {
+            Dispatcher.Invoke(() =>
+            {
+                ClearFight();
+                _fightDrops.Clear();
+            });
+        }
+
+        private void OnFightSummary()
+        {
+            Dispatcher.Invoke(UpdateData);
+        }
+
         public HudWindow(string playerName)
         {
             _playerName = playerName;
@@ -116,6 +130,9 @@ namespace BrokenHelper
             _timer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(1) };
             _timer.Tick += (_, _) => UpdateData();
             _timer.Start();
+
+            GameEvents.FightStarted += OnFightStarted;
+            GameEvents.FightSummary += OnFightSummary;
 
             UpdateData();
         }
@@ -371,6 +388,8 @@ namespace BrokenHelper
             _fightsWindow?.Close();
             _instancesWindow?.Close();
             _logsWindow?.Close();
+            GameEvents.FightStarted -= OnFightStarted;
+            GameEvents.FightSummary -= OnFightSummary;
             base.OnClosed(e);
         }
     }


### PR DESCRIPTION
## Summary
- make `FightEntity.EndTime` nullable
- add GameEvents helper for fight events
- update HUD on fight start and summary
- fix unused variable warning
- filter fights only with end time set

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685daab8bbcc8329a61a6f76fd7ac7af