### PR TITLE
Remove victory sound at end of instance

### DIFF
--- a/PacketHandlers/InstanceHandler.cs
+++ b/PacketHandlers/InstanceHandler.cs
@@ -111,10 +111,6 @@ namespace BrokenHelper.PacketHandlers
                 }
             }
 
-            if (!wasPending && _pendingClose && Preferences.SoundSignals)
-            {
-                Helpers.SoundHelper.PlayVictory();
-            }
         }
 
         public void CloseIfPending(DateTime time, Models.GameDbContext context)


### PR DESCRIPTION
## Summary
- don't play the victory sound when an instance finishes

## Testing
- `dotnet build BrokenHelper.sln -c Release` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685dacab715483299c01cbfa75cd53c1