### PR TITLE
Fix DateTime argument in fight closing

### DIFF
--- a/PacketHandlers/FightHandler.cs
+++ b/PacketHandlers/FightHandler.cs
@@ -144,7 +144,7 @@ namespace BrokenHelper.PacketHandlers
             fight.EndTime = time ?? DateTime.Now;
             context.SaveChanges();
 
-            _instanceHandler.CloseIfPending(fight.EndTime, context);
+            _instanceHandler.CloseIfPending(fight.EndTime!.Value, context);
 
             _currentFightId = null;
         }


### PR DESCRIPTION
## Summary
- fix compile error by passing `DateTime` value when closing an instance

## Testing
- `dotnet build BrokenHelper.csproj -c Release` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dad1297748329b102810eda8f8868