### PR TITLE
Add equipment categorization

### DIFF
--- a/Models/EquipmentType.cs
+++ b/Models/EquipmentType.cs
@@ -1,0 +1,9 @@
+namespace BrokenHelper.Models
+{
+    public enum EquipmentType
+    {
+        Rar,
+        Syng,
+        Trash
+    }
+}


### PR DESCRIPTION
## Summary
- classify equipment as rar/syng/trash
- compute equipment values based on new categories

## Testing
- `dotnet build -v:m` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e5796fb908329a756a2b629581372