### PR TITLE
Add DropType seeding

### DIFF
--- a/Models/DropTypeEntity.cs
+++ b/Models/DropTypeEntity.cs
@@ -1,0 +1,8 @@
+namespace BrokenHelper.Models
+{
+    public class DropTypeEntity
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+}

--- a/Models/GameDbContext.cs
+++ b/Models/GameDbContext.cs
@@ -1,5 +1,7 @@
 using Microsoft.EntityFrameworkCore;
+using System;
 using System.IO;
+using System.Linq;
 
 namespace BrokenHelper.Models
 {
@@ -10,6 +12,7 @@ namespace BrokenHelper.Models
         public DbSet<OpponentTypeEntity> OpponentTypes { get; set; }
         public DbSet<FightOpponentEntity> FightOpponents { get; set; }
         public DbSet<DropEntity> Drops { get; set; }
+        public DbSet<DropTypeEntity> DropTypes { get; set; }
         public DbSet<ItemPriceEntity> ItemPrices { get; set; }
         public DbSet<ArtifactPriceEntity> ArtifactPrices { get; set; }
 
@@ -56,6 +59,19 @@ namespace BrokenHelper.Models
             modelBuilder.Entity<ArtifactPriceEntity>()
                 .HasIndex(p => p.Name)
                 .IsUnique();
+
+            modelBuilder.Entity<DropTypeEntity>()
+                .HasIndex(t => t.Name)
+                .IsUnique();
+
+            modelBuilder.Entity<DropTypeEntity>().HasData(
+                Enum.GetValues<DropType>()
+                    .Select(v => new DropTypeEntity
+                    {
+                        Id = (int)v,
+                        Name = v.ToString()
+                    })
+                    .ToArray());
 
         }
     }


### PR DESCRIPTION
## Summary
- keep `DropType` enum on `DropEntity`
- seed the DropTypes table with enum values
- revert drop parsing logic to use enum
- adjust stats logic accordingly

## Testing
- `dotnet build BrokenHelper.csproj` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e5be67d988329a3b03a60e071a6dc