### PR TITLE
Normalize Drops with Items table

### DIFF
--- a/Models/DropEntity.cs
+++ b/Models/DropEntity.cs
@@ -7,18 +7,10 @@ namespace BrokenHelper.Models
         public int FightId { get; set; }
         public FightEntity Fight { get; set; } = null!;
 
-        public DropType DropType { get; set; }
+        public int ItemId { get; set; }
+        public ItemEntity Item { get; set; } = null!;
 
-        public string Name { get; set; } = string.Empty;
-
-        public int? Value { get; set; }
-
-        // Equipment-specific
-        public int? Rank { get; set; }
         public int? OrnamentCount { get; set; }
-
-        // Orb/Drif-specific
-        public string? Code { get; set; }
 
         public int Quantity { get; set; } = 1;
     }

--- a/Models/GameDbContext.cs
+++ b/Models/GameDbContext.cs
@@ -12,6 +12,7 @@ namespace BrokenHelper.Models
         public DbSet<OpponentTypeEntity> OpponentTypes { get; set; }
         public DbSet<FightOpponentEntity> FightOpponents { get; set; }
         public DbSet<DropEntity> Drops { get; set; }
+        public DbSet<ItemEntity> Items { get; set; }
         public DbSet<DropTypeEntity> DropTypes { get; set; }
         public DbSet<ItemPriceEntity> ItemPrices { get; set; }
         public DbSet<ArtifactPriceEntity> ArtifactPrices { get; set; }
@@ -51,6 +52,10 @@ namespace BrokenHelper.Models
 
             modelBuilder.Entity<ItemPriceEntity>()
                 .HasIndex(p => p.Name)
+                .IsUnique();
+
+            modelBuilder.Entity<ItemEntity>()
+                .HasIndex(i => i.Name)
                 .IsUnique();
 
             modelBuilder.Entity<ArtifactPriceEntity>()

--- a/Models/ItemEntity.cs
+++ b/Models/ItemEntity.cs
@@ -1,0 +1,16 @@
+using System.Collections.Generic;
+
+namespace BrokenHelper.Models
+{
+    public class ItemEntity
+    {
+        public int Id { get; set; }
+        public DropType Type { get; set; }
+        public string Name { get; set; } = string.Empty;
+        public int? Value { get; set; }
+        public int? Rank { get; set; }
+        public string? Code { get; set; }
+
+        public List<DropEntity> Drops { get; set; } = [];
+    }
+}

--- a/Packets/PacketHandlers/PriceHandler.cs
+++ b/Packets/PacketHandlers/PriceHandler.cs
@@ -60,6 +60,26 @@ namespace BrokenHelper.PacketHandlers
                         existing.Value = value;
                         existing.Name = name;
                     }
+
+                    var item = context.Items.Local.FirstOrDefault(i => i.Name == name) ??
+                               context.Items.FirstOrDefault(i => i.Name == name);
+                    if (item == null)
+                    {
+                        item = new Models.ItemEntity
+                        {
+                            Name = name,
+                            Code = code,
+                            Value = value,
+                            Type = Models.DropType.Drif
+                        };
+                        context.Items.Add(item);
+                    }
+                    else
+                    {
+                        item.Code = code;
+                        item.Value = value;
+                        item.Type = Models.DropType.Drif;
+                    }
                 }
                 else
                 {
@@ -87,6 +107,24 @@ namespace BrokenHelper.PacketHandlers
                     else
                     {
                         existing.Value = value;
+                    }
+
+                    var item = context.Items.Local.FirstOrDefault(i => i.Name == name) ??
+                               context.Items.FirstOrDefault(i => i.Name == name);
+                    if (item == null)
+                    {
+                        item = new Models.ItemEntity
+                        {
+                            Name = name,
+                            Value = value,
+                            Type = Models.DropType.Item
+                        };
+                        context.Items.Add(item);
+                    }
+                    else
+                    {
+                        item.Value = value;
+                        item.Type = Models.DropType.Item;
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- introduce `ItemEntity` for shared item details
- reference items from drops instead of storing fields directly
- add unique index on item names
- load item info when parsing drops and prices
- compute stats based on `ItemEntity`

## Testing
- `dotnet build -clp:ErrorsOnly` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e62d537788329ab9cdcb048bc4de3