### PR TITLE
Fix HUD fight display before summary

### DIFF
--- a/Views/HudWindow.xaml.cs
+++ b/Views/HudWindow.xaml.cs
@@ -38,6 +38,7 @@ namespace BrokenHelper
         private List<DropSummaryDetailed> _instanceDrops = [];
 
         private DateTime? _fightStartTime;
+        private bool _fightSummaryReceived;
 
         private void OnFightStarted()
         {
@@ -46,6 +47,7 @@ namespace BrokenHelper
                 ClearFight();
                 _fightDrops.Clear();
                 _fightStartTime = DateTime.Now;
+                _fightSummaryReceived = false;
                 _fightDurationValue.Text = "0:00";
                 _fightDurationValue.Foreground = Brushes.White;
             });
@@ -53,6 +55,7 @@ namespace BrokenHelper
 
         private void OnFightSummary()
         {
+            _fightSummaryReceived = true;
             Dispatcher.Invoke(UpdateData);
         }
 
@@ -254,9 +257,14 @@ namespace BrokenHelper
             }
 
             var fight = StatsService.GetLastFightSummary(player);
-            if (fight == null)
+            bool showStats = _fightSummaryReceived || _fightStartTime == null;
+
+            if (!showStats || fight == null)
             {
-                ClearFight();
+                _fightExpValue.Text = "-";
+                _fightPsychoValue.Text = "-";
+                _fightGoldValue.Text = "-";
+                _fightDropValue.Text = "-";
                 _fightDrops.Clear();
             }
             else


### PR DESCRIPTION
## Summary
- avoid showing stats from the previous fight right after receiving packet `3;1;`
- keep placeholders and timer until fight summary packet `3;19;` is handled

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e9155df148329bd253d1218ee61d2