### PR TITLE
Add lock price support for items

### DIFF
--- a/Models/ItemEntity.cs
+++ b/Models/ItemEntity.cs
@@ -10,6 +10,7 @@ namespace BrokenHelper.Models
         public int? Value { get; set; }
         public int? Rank { get; set; }
         public string? Code { get; set; }
+        public bool LockPrice { get; set; }
 
         public List<DropEntity> Drops { get; set; } = [];
     }

--- a/PacketHandlers/FightHandler.cs
+++ b/PacketHandlers/FightHandler.cs
@@ -219,7 +219,7 @@ namespace BrokenHelper.PacketHandlers
             else
             {
                 item.DropType = type;
-                if (value.HasValue) item.Value = value;
+                if (value.HasValue && !item.LockPrice) item.Value = value;
                 if (rank.HasValue) item.Rank = rank;
                 if (code != null) item.Code = code;
             }

--- a/PacketHandlers/PriceHandler.cs
+++ b/PacketHandlers/PriceHandler.cs
@@ -55,7 +55,7 @@ namespace BrokenHelper.PacketHandlers
                     else
                     {
                         item.Code = code;
-                        item.Value = value;
+                        if (!item.LockPrice) item.Value = value;
                         item.DropType = Models.DropType.Drif;
                     }
                 }
@@ -82,7 +82,7 @@ namespace BrokenHelper.PacketHandlers
                     }
                     else
                     {
-                        item.Value = value;
+                        if (!item.LockPrice) item.Value = value;
                         item.DropType = Models.DropType.Item;
                     }
                 }


### PR DESCRIPTION
## Summary
- extend `ItemEntity` with `LockPrice`
- prevent price updates from packets when `LockPrice` is true

## Testing
- `dotnet build` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ffb89a31c832982846fc833449408