### PR TITLE
Improve capture start error handling

### DIFF
--- a/Packets/PacketListener.cs
+++ b/Packets/PacketListener.cs
@@ -44,9 +44,30 @@ namespace BrokenHelper
                 throw new InvalidOperationException("No capture device found");
 
             _device.OnPacketArrival += OnPacketArrival;
-            _device.Open(DeviceModes.Promiscuous, 1000);
-            _device.Filter = "tcp src port 9365";
-            _device.StartCapture();
+            bool opened = false;
+            try
+            {
+                _device.Open(DeviceModes.Promiscuous, 1000);
+                opened = true;
+                _device.Filter = "tcp src port 9365";
+                _device.StartCapture();
+            }
+            catch (PcapException)
+            {
+                if (opened)
+                    _device.Close();
+                _device.OnPacketArrival -= OnPacketArrival;
+                _device = null;
+                throw;
+            }
+            catch (Exception)
+            {
+                if (opened)
+                    _device.Close();
+                _device.OnPacketArrival -= OnPacketArrival;
+                _device = null;
+                throw;
+            }
         }
 
         public void Stop()

--- a/Views/HudWindow.xaml.cs
+++ b/Views/HudWindow.xaml.cs
@@ -389,9 +389,24 @@ namespace BrokenHelper
         {
             if (_listener == null)
             {
-                _listener = new PacketListener();
-                _listener.Start();
-                _listenMenuItem.Header = "Wy\u0142\u0105cz nas\u0142uchiwanie";
+                var listener = new PacketListener();
+                try
+                {
+                    listener.Start();
+                    _listener = listener;
+                    _listenMenuItem.Header = "Wy\u0142\u0105cz nas\u0142uchiwanie";
+                }
+                catch (Exception ex)
+                {
+                    MessageBox.Show(
+                        $"Nie uda\u0142o si\u0119 rozpocz\u0105\u0107 nas\u0142uchiwania pakiet\u00f3w. Upewnij si\u0119, \u017ce aplikacja jest uruchomiona z uprawnieniami administratora.\n\n{ex.Message}",
+                        "B\u0142\u0105d",
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Error);
+                    listener.Stop();
+                    _listener = null;
+                    _listenMenuItem.Header = "W\u0142\u0105cz nas\u0142uchiwanie";
+                }
             }
             else
             {


### PR DESCRIPTION
## Summary
- guard packet capture start with try/catch
- show a message box if starting the packet listener fails

## Testing
- `dotnet build -nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68602e50e8088329aa52bc64655a6183