### PR TITLE
Handle config parse errors

### DIFF
--- a/GameConfig.cs
+++ b/GameConfig.cs
@@ -35,7 +35,16 @@ namespace BrokenHelper
             if (!File.Exists(path))
                 return;
             var json = File.ReadAllText(path);
-            var cfg = JsonSerializer.Deserialize<ConfigModel>(json) ?? new ConfigModel();
+            ConfigModel cfg;
+            try
+            {
+                cfg = JsonSerializer.Deserialize<ConfigModel>(json) ?? new ConfigModel();
+            }
+            catch (Exception ex)
+            {
+                Logger.Add("GameConfig", $"Failed to deserialize config: {ex.Message}", DateTime.Now);
+                cfg = new ConfigModel();
+            }
             BossGroups = cfg.BossGroups ?? [];
             MultiKillBosses = cfg.MultiKillBosses ?? [];
             SingleBosses = cfg.SingleBosses != null ? new HashSet<string>(cfg.SingleBosses) : [];


### PR DESCRIPTION
## Summary
- catch exceptions when loading config JSON
- log deserialization errors and use default values

## Testing
- `dotnet build BrokenHelper.sln` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68602e52b6488329b11955c39f58499a